### PR TITLE
(SIMP-321) Allow empty log_servers Hiera parameter

### DIFF
--- a/build/pupmod-rsyslog.spec
+++ b/build/pupmod-rsyslog.spec
@@ -1,7 +1,7 @@
 Summary: Rsyslog Puppet Module
 Name: pupmod-rsyslog
 Version: 4.1.0
-Release: 13
+Release: 14
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -60,6 +60,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Tue Feb 28 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-14
+- Ensure that the lack of specified rsyslog servers does not fail the compile.
+
 * Thu Feb 19 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-13
 - Migrated to the new 'simp' environment.
 

--- a/spec/classes/global_spec.rb
+++ b/spec/classes/global_spec.rb
@@ -48,6 +48,12 @@ describe 'rsyslog::global' do
       it { should create_concat_fragment('rsyslog+global').with_content(/MainMsgQueueMaxDiskSpace 20M/) }
 
       it { should create_file('/etc/sysconfig/rsyslog') }
+
+      context 'actionSendStreamDriverPermittedPeers should be optional' do
+        let(:params) {{ :actionSendStreamDriverPermittedPeers => [] }}
+
+        it { should compile.with_all_deps }
+      end
     end
   end
 

--- a/templates/rsyslog.conf.global.erb
+++ b/templates/rsyslog.conf.global.erb
@@ -48,7 +48,7 @@
 
   # This pulls out all of the wildcard entries so that we don't try to validate
   # them later on.
-  t_peers = @actionSendStreamDriverPermittedPeers.dup
+  t_peers = @actionSendStreamDriverPermittedPeers.map{|x| scope.function_strip_ports([x])}
   t_wildcard_peers = []
   t_peers.delete_if{|x| if x =~ /\*/ then t_wildcard_peers << x and true end}
 -%>
@@ -79,7 +79,7 @@ $DefaultNetstreamDriverCertFile <%= @defaultNetStreamDriverCertFile %>
 $DefaultNetstreamDriverKeyFile <%= @defaultNetStreamDriverKeyFile %>
 $ActionSendStreamDriverMode 1
 $ActionSendStreamDriverAuthMode <%= @actionSendStreamDriverAuthMode %>
-<%   (t_wildcard_peers + scope.function_strip_ports([t_peers])).each do |peer| -%>
+<%   (t_wildcard_peers + t_peers).each do |peer| -%>
 $ActionSendStreamDriverPermittedPeer <%= peer %>
 <%   end -%>
 <% end -%>


### PR DESCRIPTION
This updates the system to ensure that the global template does not fail
if actionSendStreamDriverPermittedPeers is an empty array.

SIMP-321 #close #comment Fix for actionSendStreamDriverPermittedPeers being an empty array