### PR TITLE
(SIMP-192) Add acceptance tests

### DIFF
--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -32,3 +32,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  vagrant_mem: 384

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -9,3 +9,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  vagrant_mem: 384

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -30,5 +30,6 @@ HOSTS:
     box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
 CONFIG:
-  log_level: verbose
-  type: foss
+  log_level:       verbose
+  type:            foss
+  vagrant_memsize: 384

--- a/spec/acceptance/nodesets/fedora-20-x64.yml
+++ b/spec/acceptance/nodesets/fedora-20-x64.yml
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  vagrant_mem: 512


### PR DESCRIPTION
Before this commit, there was no way to automate acceptance testing for
rsyslog.  This patch adds Beaker acceptance tests to rsyslog and fixes
logic that was found to fail during tests (enough to achieve minimum
viable test runs).

SIMP-192 #comment Added rsyslog tests for default installation
SIMP-192 #comment Added rsyslog tests for 1 client 1 server, TCP/plain
SIMP-192 #comment Added rsyslog tests for 1 client 1 server, TCP/TLS
SIMP-411 #close #comment Added rsyslog tests for default installation
SIMP-421 #close #comment Added rsyslog tests: 1 client 1 server, plain
SIMP-406 #close #comment Added rsyslog tests: 1 client 1 server, w/TLS

Change-Id: I7bc3e69ab3eece9b3b6af4f6cfdfc9e56844f4b4