### PR TITLE
(SIMP-192) Reduce memory usage of acceptance tests

### DIFF
--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -30,5 +30,6 @@ HOSTS:
     box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
     hypervisor: vagrant
 CONFIG:
-  log_level: verbose
-  type: foss
+  log_level:   verbose
+  type:        foss
+  vagrant_mem: 256

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -7,5 +7,6 @@ HOSTS:
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
 CONFIG:
-  log_level: verbose
-  type: foss
+  log_level:   verbose
+  type:        foss
+  vagrant_mem: 256

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -30,5 +30,6 @@ HOSTS:
     box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
 CONFIG:
-  log_level: verbose
-  type: foss
+  log_level:       verbose
+  type:            foss
+  vagrant_memsize: 256

--- a/spec/acceptance/nodesets/fedora-20-x64.yml
+++ b/spec/acceptance/nodesets/fedora-20-x64.yml
@@ -8,5 +8,6 @@ HOSTS:
     hypervisor: vagrant
 
 CONFIG:
-  log_level: verbose
-  type: foss
+  log_level:   verbose
+  type:        foss
+  vagrant_mem: 512


### PR DESCRIPTION
Before this commit, a 4-host acceptance test run took 4GB RAM to run.
This update reduces the RAM requirement per VM from 1GB to 384MB.

SIMP-192 #comment Reduced per-VM RAM footprint for acceptance tests