### PR TITLE
(SIMP-192) Update acceptance tests for PKI update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers'
+  gem 'simp-beaker-helpers', '>= 1.0.5'
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'

--- a/spec/acceptance/client_server_using_tls_spec.rb
+++ b/spec/acceptance/client_server_using_tls_spec.rb
@@ -15,7 +15,7 @@ describe 'rsyslog client -> 1 server using TLS' do
         enable_tls_logging => true,
         enable_pki         => true,
         use_simp_pki       => false,
-        cert_source        => '/etc/pki/simp-testing',
+        cert_source        => '/etc/pki/simp-testing/pki',
       }
 
       rsyslog::rule::remote { 'send_the_logs':
@@ -41,7 +41,7 @@ describe 'rsyslog client -> 1 server using TLS' do
         enable_pki         => true,
         client_nets        => 'any',
         use_simp_pki       => false,
-        cert_source        => '/etc/pki/simp-testing',
+        cert_source        => '/etc/pki/simp-testing/pki',
       }
 
       class { 'rsyslog::server':

--- a/spec/acceptance/failover_using_tls_spec.rb
+++ b/spec/acceptance/failover_using_tls_spec.rb
@@ -21,7 +21,7 @@ describe 'rsyslog class' do
       'rsyslog::enable_tls_logging' => true,
       'rsyslog::enable_pki'         => true,
       'rsyslog::use_simp_pki'       => false,
-      'rsyslog::cert_source'        => '/etc/pki/simp-testing'
+      'rsyslog::cert_source'        => '/etc/pki/simp-testing/pki'
     }
   }
   let(:client_manifest) {
@@ -42,7 +42,7 @@ describe 'rsyslog class' do
       'rsyslog::enable_tls_logging'   => true,
       'rsyslog::enable_pki'           => true,
       'rsyslog::use_simp_pki'         => false,
-      'rsyslog::cert_source'          => '/etc/pki/simp-testing'
+      'rsyslog::cert_source'          => '/etc/pki/simp-testing/pki'
     }
   }
 
@@ -54,7 +54,7 @@ describe 'rsyslog class' do
       'rsyslog::enable_tls_logging'                    => true,
       'rsyslog::enable_pki'                            => true,
       'rsyslog::use_simp_pki'                          => false,
-      'rsyslog::cert_source'                           => '/etc/pki/simp-testing',
+      'rsyslog::cert_source'                           => '/etc/pki/simp-testing/pki',
       'rsyslog::config::main_msg_queue_high_watermark' => '2',
       'rsyslog::config::main_msg_queue_low_watermark'  => '1'
     }
@@ -81,7 +81,7 @@ describe 'rsyslog class' do
       'rsyslog::tls_tcp_server'             => true,
       'rsyslog::enable_pki'                 => true,
       'rsyslog::use_simp_pki'               => false,
-      'rsyslog::cert_source'                => '/etc/pki/simp-testing',
+      'rsyslog::cert_source'                => '/etc/pki/simp-testing/pki',
       'rsyslog::client_nets'                => 'any',
       'rsyslog::server::enable_firewall'    => true,
       'rsyslog::server::enable_selinux'     => true,


### PR DESCRIPTION
The SIMP beaker Gem was updated to better mirror the action of
::pki::copy. This adjusts the acceptance tests accordingly.

SIMP-192 #comment PKI Acceptance Test Update

Change-Id: Ibbc56dac24e5a4a3a4476cc8f4dabe02621f57a9