### PR TITLE
(SIMP-567) Remove rsyslog before rsyslog7 install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'rake'
   gem 'puppet', puppetversion
   gem 'rspec', '< 3.2.0'
-  gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'rspec-puppet'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'simp-rspec-puppet-facts'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,13 +5,19 @@
 class rsyslog::install {
   assert_private()
 
-  package { "${::rsyslog::package_name}.${::hardwaremodel}": ensure => 'latest' }
+  $full_rsyslog_package = "${::rsyslog::package_name}.${::hardwaremodel}"
+
+  package { $full_rsyslog_package: ensure => 'latest' }
 
   # remove existing/conflicting packages
   if $::rsyslog::package_name == 'rsyslog7' {
-    package { "rsyslog.${::hardwaremodel}": ensure => 'absent' }
+    package { "rsyslog.${::hardwaremodel}":
+     ensure            => 'absent',
+     uninstall_options => ['--nodeps'],
+     provider          => 'rpm',
+    }
     ->
-    Package["${::rsyslog::package_name}.${::hardwaremodel}"]
+    Package[$full_rsyslog_package]
   }
 
 
@@ -19,9 +25,13 @@ class rsyslog::install {
   # system.
   if $::hardwaremodel == 'x86_64' {
     package { "${::rsyslog::package_name}.i386": ensure => 'absent' }
+    ->
+    Package[$full_rsyslog_package]
   }
 
   if ( $::rsyslog::enable_tls_logging or $::rsyslog::tls_tcp_server ) {
+    Package[$full_rsyslog_package]
+    ->
     package { "${::rsyslog::tls_package_name}": ensure => 'latest', }
   }
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -22,19 +22,6 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
-  # FIXME: The EL6 tests need to install rsyslog7.  However, puppetlabs'
-  # centos6 vagrant box comes with rsyslog + a big dep chain, which stops
-  # rsyslog7 from getting installed.
-  #
-  # This workaround shanks rsyslog out of the way, however the module itself
-  # should handle this upgrade somehow.
-  hosts.each do |sut|
-    if fact_on(sut, 'osfamily') == 'RedHat' && fact_on(sut, 'operatingsystemmajrelease') == '6'
-      on(sut, 'rpm -q rsyslog && rpm -e --nodeps rsyslog', :accept_all_exit_codes => true )
-      puts '*'*400 + " ^^ FIXME in the module!"
-    end
-  end
-
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
Before this commit, it was impossible to use this module to install
`rsyslog7` on an EL6 system using the stock `rsyslog` (v5) without
force-uninstalling rsyslog while ignoring dependencies.

This commit ensures that `rsyslog` is uninstalled without dependencies
before installing `rsyslog7`.

NOTE: If the package exchange occurs on an actively logging system,
logging will be very briefly interrupted during the interregnum.

SIMP-567 #close #comment Remove rsyslog before installing rsyslog7.