### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 .*.sw?
+.yardoc
 dist
 /pkg
 /spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
 /.rspec_system
 /.vagrant
 /.bundle
-/vendor
 /Gemfile.lock
+/vendor
 /junit
 /log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,19 +2,22 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  gem 'rake'
+  gem "rake"
   gem 'puppet', puppetversion
-  gem 'rspec', '< 3.2.0'
-  gem 'rspec-puppet'
-  gem 'puppetlabs_spec_helper'
-  gem 'metadata-json-lint'
-  gem 'simp-rspec-puppet-facts'
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
+
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
@@ -26,11 +29,11 @@ group :test do
 end
 
 group :development do
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'vagrant-wrapper'
-  gem 'puppet-blacksmith'
-  gem 'guard-rake'
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
   gem 'pry'
   gem 'pry-doc'
 end
@@ -38,7 +41,11 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
   gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -229,9 +229,9 @@ class rsyslog::config (
   # set the driver auth_mode based on the mode
   if empty( $action_send_stream_driver_auth_mode ) {
     $l_action_send_stream_driver_auth_mode = $action_send_stream_driver_mode ? {
-       '0'     => 'anon',
-       '1'     => 'x509/name',
-       default => 'x509/name',
+      '0'     => 'anon',
+      '1'     => 'x509/name',
+      default => 'x509/name',
     }
   } else {
     $l_action_send_stream_driver_auth_mode = $action_send_stream_driver_auth_mode

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -27,10 +27,10 @@ class rsyslog::config::pki {
   }
   else {
     file { '/etc/rsyslog.d/pki':
-      ensure  => 'directory',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0640'
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0640'
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,9 +12,9 @@ class rsyslog::install {
   # remove existing/conflicting packages
   if $::rsyslog::package_name == 'rsyslog7' {
     package { "rsyslog.${::hardwaremodel}":
-     ensure            => 'absent',
-     uninstall_options => ['--nodeps'],
-     provider          => 'rpm',
+      ensure            => 'absent',
+      uninstall_options => ['--nodeps'],
+      provider          => 'rpm',
     }
     ->
     Package[$full_rsyslog_package]
@@ -32,6 +32,6 @@ class rsyslog::install {
   if ( $::rsyslog::enable_tls_logging or $::rsyslog::tls_tcp_server ) {
     Package[$full_rsyslog_package]
     ->
-    package { "${::rsyslog::tls_package_name}": ensure => 'latest', }
+    package { $::rsyslog::tls_package_name: ensure => 'latest', }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,9 +4,8 @@
 #
 class rsyslog::params {
   $service_name       = 'rsyslog'
-  if ($::operatingsystem in ['RedHat','CentOS']) and
-     ("${::operatingsystemmajrelease}" == '6') {
-       $package_name = 'rsyslog7'
+  if ($::operatingsystem in ['RedHat','CentOS']) and ($::operatingsystemmajrelease == '6') {
+    $package_name = 'rsyslog7'
   }
   else {
     $package_name = 'rsyslog'

--- a/manifests/server/selinux.pp
+++ b/manifests/server/selinux.pp
@@ -5,7 +5,7 @@
 class rsyslog::server::selinux {
   assert_private()
 
-  if ($::operatingsystem in ['RedHat','CentOS']) and ("${::operatingsystemmajrelease}" > '6') {
+  if ($::operatingsystem in ['RedHat','CentOS']) and ($::operatingsystemmajrelease > '6') {
     if $::selinux_current_mode and $::selinux_current_mode != 'disabled' {
       # nis_enabled must be turned on for socket connections.
       selboolean { 'nis_enabled':


### PR DESCRIPTION
This commit synchronizes all common static module assets with current SIMP
module standards.

Also:
- created .puppet-lint.rc, .travis.yml, .gitignore

SIMP-667 #comment updated `pupmod-simp-rsyslog`
SIMP-741 #close #comment normalized common module assets