### PR TITLE
(SIMP-956) Allow users to toggle TLS for forward

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,24 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'puppet', puppetversion
+
+  # Puppet 4+ has issues with Hiera 3.1+
+  if puppetversion.to_s =~ />(\d+)/
+    pversion = $1
+  else
+    pversion = puppetversion
+  end
+
+  if Gem::Dependency.new('puppet', '~> 4.0').match?('puppet',pversion)
+    gem 'hiera', '~> 3.0.0'
+  end
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&

--- a/build/pupmod-rsyslog.spec
+++ b/build/pupmod-rsyslog.spec
@@ -1,6 +1,6 @@
 Summary: Rsyslog Puppet Module
 Name: pupmod-rsyslog
-Version: 5.1.0
+Version: 5.1.1
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -58,6 +58,9 @@ mkdir -p %{buildroot}/%{prefix}/rsyslog
 # Post uninstall stuff
 
 %changelog
+* Thu Mar 24 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.1-0
+- Added the ability to toggle TLS on remote Rsyslog forwarders.
+
 * Mon Mar 21 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-0
 - Migrated to Semantic Versioning 2.0
 - Fixed a bug where the ability to use custom templates was omitted from the

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -33,4 +33,6 @@ class rsyslog::config::pki {
       mode   => '0640'
     }
   }
+
+  Class['rsyslog::config::pki'] ~> Class['rsyslog::service']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,6 +138,5 @@ class rsyslog (
 
   if $enable_pki {
     include '::rsyslog::config::pki'
-    Class['rsyslog::config::pki'] ~> Class['rsyslog::service']
   }
 }

--- a/manifests/rule/remote.pp
+++ b/manifests/rule/remote.pp
@@ -63,6 +63,12 @@
 #    not use legacy syslog syntax. For complete documentation on RSyslog
 #    omfwd options, visit http://www.rsyslog.com/doc/v7-stable/configuration/modules/omfwd.html
 #
+# [*use_tls*]
+#  Type: Boolean
+#  Default: $::rsyslog::enable_tls_logging
+#
+#    If true, use TLS for this connection.
+#
 define rsyslog::rule::remote (
   $rule,
   $template                             = '',
@@ -109,7 +115,8 @@ define rsyslog::rule::remote (
   $queue_save_on_shutdown               = true,
   $queue_dequeue_slowdown               = '0',
   $queue_dequeue_time_begin             = '',
-  $queue_dequeue_time_end               = ''
+  $queue_dequeue_time_end               = '',
+  $use_tls                              = ''
 ) {
 
   validate_string($template)
@@ -173,7 +180,17 @@ define rsyslog::rule::remote (
     true    => $::rsyslog::queue_spool_directory,
     default => $queue_spool_directory
   }
-  $_use_tls = $::rsyslog::enable_tls_logging
+
+  if empty($use_tls) {
+    $_use_tls = $::rsyslog::enable_tls_logging
+  }
+  elsif $use_tls {
+    include '::rsyslog::config::pki'
+    $_use_tls = true
+  }
+  else {
+    $_use_tls = false
+  }
 
   if empty($failover_log_servers) {
     $_failover_servers = $::rsyslog::failover_log_servers

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-rsyslog",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "author":  "SIMP",
   "summary": "A puppet module to support RSyslog versions 7 and higher using new style RainerScript.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Previously, remote rules were bound to the TLS settings for the entire
Rsyslog environment. This change allows users to select TLS on an
individual forwarding basis and pulls in rsyslog::config::pki as
appropriate.

SIMP-956 #close
