### PR TITLE
(SIMP-2439) Fix and test `iptables::listen::`

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,28 +1,41 @@
 ---
 fixtures:
   repositories:
-    auditd: https://github.com/simp/pupmod-simp-auditd
+    auditd:
+      repo: https://github.com/simp/pupmod-simp-auditd
+      tag: 7.0.0-pre1
     augeasproviders_core:
       repo: https://github.com/simp/augeasproviders_core
-      branch: simp-master
+      tag: simp-2.1.1
     augeasproviders_grub:
       repo: https://github.com/simp/augeasproviders_grub
-      branch: simp-master
+      tag: simp-2.3.1
     concat:
       repo: https://github.com/simp/puppetlabs-concat
-      branch: simp-master
+      tag: 2.2.0
     haveged:
       repo: https://github.com/simp/puppet-haveged
-      branch: simp-master
-    iptables: https://github.com/simp/pupmod-simp-iptables
-    logrotate: https://github.com/simp/pupmod-simp-logrotate
-    pki: https://github.com/simp/pupmod-simp-pki
-    simpcat: https://github.com/simp/pupmod-simp-simpcat
-    simplib: https://github.com/simp/pupmod-simp-simplib
+      tag: simp-0.4.0-pre1
+    iptables:
+      repo: https://github.com/simp/pupmod-simp-iptables
+      tage: 6.0.0-pre1
+    logrotate:
+      repo: https://github.com/simp/pupmod-simp-logrotate
+      tag: 6.0.0-pre1
+    pki:
+      repo: https://github.com/simp/pupmod-simp-pki
+      tag: 6.0.0-pre1
+    simplib:
+      repo: https://github.com/simp/pupmod-simp-simplib
+      tag: 3.1.0
     stdlib:
       repo: https://github.com/simp/puppetlabs-stdlib
-      branch: master
-    stunnel: https://github.com/simp/pupmod-simp-stunnel
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
+      tag: 4.13.1
+    stunnel:
+      repo: https://github.com/simp/pupmod-simp-stunnel
+      tag: 6.0.0-pre1
+    tcpwrappers:
+      repo: https://github.com/simp/pupmod-simp-tcpwrappers
+      tag: 6.0.0-pre1
   symlinks:
     rsyslog: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ dist
 /.rspec_system
 /.vagrant
 /.bundle
-/Gemfile.lock
 /vendor
 /junit
 /log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
-sudo: true
+sudo: false
 cache: bundler
 before_script:
   - bundle
@@ -24,17 +27,17 @@ env:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+    - PUPPET_VERSION="~> 4.8.1"
     - PUPPET_VERSION="~> 4.7.0"
     - PUPPET_VERSION="~> 4.5.0"
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
   fast_finish: true
   allow_failures:
+    - env: PUPPET_VERSION="~> 4.7.0"
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,466 @@
+GIT
+  remote: https://github.com/trevor-vaughan/beaker.git
+  revision: 9d5c8bcd7dd505a10eadc19f84f963f0fc409fdd
+  branch: BKR-978-2.51.0
+  specs:
+    beaker (2.51.0)
+      aws-sdk-v1 (~> 1.57)
+      beaker-answers (~> 0.0)
+      beaker-hiera (~> 0.0)
+      beaker-hostgenerator
+      beaker-pe (~> 0.0)
+      docker-api
+      fission (~> 0.4)
+      fog (~> 1.25, < 1.35.0)
+      fog-google (~> 0.0.9)
+      google-api-client (~> 0.8, < 0.9.5)
+      hocon (~> 1.0)
+      in-parallel (~> 0.1)
+      inifile (~> 2.0)
+      json (~> 1.8)
+      minitest (~> 5.4)
+      net-scp (~> 1.2)
+      net-ssh (~> 2.9)
+      open_uri_redirections (~> 0.2.1)
+      rbvmomi (~> 1.8, < 1.9.0)
+      rsync (~> 1.0.9)
+      stringify-hash (~> 0.0)
+      unf (~> 0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    addressable (2.4.0)
+    aws-sdk-v1 (1.66.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+    backports (3.6.8)
+    beaker-answers (0.13.0)
+      hocon (~> 1.0)
+      require_all (~> 1.3.2)
+      stringify-hash (~> 0.0.0)
+    beaker-hiera (0.1.1)
+      stringify-hash (~> 0.0.0)
+    beaker-hostgenerator (0.8.2)
+      deep_merge (~> 1.0)
+      stringify-hash (~> 0.0.0)
+    beaker-pe (0.12.1)
+      stringify-hash (~> 0.0.0)
+    beaker-rspec (5.6.0)
+      beaker (~> 2.0)
+      rspec
+      serverspec (~> 2)
+      specinfra (~> 2)
+    builder (3.2.2)
+    coderay (1.1.1)
+    colored (1.2)
+    cri (2.6.1)
+      colored (~> 1.2)
+    deep_merge (1.1.1)
+    diff-lcs (1.2.5)
+    docker-api (1.33.1)
+      excon (>= 0.38.0)
+      json
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
+    ethon (0.10.1)
+      ffi (>= 1.3.0)
+    excon (0.54.0)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
+    fast_gettext (1.1.0)
+    ffi (1.9.14)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.34.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.32)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (1.1.0)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.11.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.43.0)
+      builder
+      excon (~> 0.49)
+      formatador (~> 0.2)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.0.9)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.3.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (3.0.0)
+      fog-core (~> 1.42)
+      fog-json (~> 1.0)
+    fog-radosgw (0.0.5)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.7.5)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.1.4)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    gettext (3.2.2)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.10)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
+    gh (0.15.0)
+      addressable (~> 2.4.0)
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (~> 2.9)
+      net-http-pipeline
+    google-api-client (0.9.4)
+      addressable (~> 2.3)
+      googleauth (~> 0.5)
+      httpclient (~> 2.7)
+      hurley (~> 0.1)
+      memoist (~> 0.11)
+      mime-types (>= 1.6)
+      representable (~> 2.3.0)
+      retriable (~> 2.0)
+      thor (~> 0.19)
+    googleauth (0.5.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
+    guard (2.14.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-rake (1.0.0)
+      guard
+      rake
+    hiera (3.2.2)
+    hiera-puppet-helper (1.0.1)
+    highline (1.7.8)
+    hocon (1.2.4)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    httpclient (2.8.3)
+    hurley (0.2)
+    in-parallel (0.1.15)
+    inflecto (0.0.2)
+    inifile (2.0.2)
+    ipaddress (0.8.3)
+    json (1.8.3)
+    json_pure (1.8.3)
+    jwt (1.5.6)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    little-plugger (1.1.4)
+    locale (2.1.2)
+    log4r (1.1.10)
+    logging (2.1.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    lumberjack (1.0.10)
+    memoist (0.15.0)
+    metaclass (0.0.4)
+    metadata-json-lint (1.0.0)
+      json
+      semantic_puppet (>= 0.1.2, < 2.0.0)
+      spdx-licenses (~> 1.0)
+    method_source (0.8.2)
+    mime-types (2.99.3)
+    mini_portile2 (2.1.0)
+    minitar (0.5.4)
+    minitest (5.10.1)
+    mocha (1.2.1)
+      metaclass (~> 0.0.1)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    nenv (0.3.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.4)
+    net-telnet (0.1.1)
+    netrc (0.11.0)
+    nokogiri (1.7.0.1)
+      mini_portile2 (~> 2.1.0)
+    notiffany (0.1.1)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    open_uri_redirections (0.2.1)
+    os (0.9.6)
+    pager (1.0.1)
+    parallel (1.10.0)
+    parallel_tests (2.12.0)
+      parallel
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-doc (0.10.0)
+      pry (~> 0.9)
+      yard (~> 0.9)
+    puppet (4.8.1)
+      CFPropertyList (~> 2.2.6)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
+      json_pure (~> 1.8)
+    puppet-blacksmith (3.4.0)
+      puppet (>= 2.7.16)
+      rest-client (~> 1.8.0)
+    puppet-lint (2.1.0)
+    puppet-lint-empty_string-check (0.2.2)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-lint-trailing_comma-check (0.3.2)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-strings (1.0.0)
+      yard (~> 0.9.5)
+    puppet-syntax (2.2.0)
+      rake
+    puppet_forge (2.2.2)
+      faraday (~> 0.9.0)
+      faraday_middleware (>= 0.9.0, < 0.11.0)
+      gettext-setup (>= 0.3)
+      minitar
+      semantic_puppet (~> 0.1.0)
+    puppetlabs_spec_helper (0.10.3)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
+    r10k (2.5.1)
+      colored (= 1.2)
+      cri (~> 2.6.1)
+      gettext-setup (~> 0.5)
+      log4r (= 1.1.10)
+      minitar
+      multi_json (~> 1.10)
+      puppet_forge (~> 2.2)
+      semantic_puppet (~> 0.1.0)
+    rake (11.3.0)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    representable (2.3.0)
+      uber (~> 0.0.7)
+    require_all (1.3.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    retriable (2.1.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-puppet (2.5.0)
+      rspec
+    rspec-puppet-facts (0.12.0)
+      facter
+      json
+    rspec-support (3.5.0)
+    rsync (1.0.9)
+    semantic_puppet (0.1.4)
+      gettext-setup (>= 0.3)
+    serverspec (2.37.2)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.53)
+    sfl (2.3)
+    shellany (0.0.1)
+    signet (0.7.3)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
+    simp-beaker-helpers (1.5.6)
+      beaker (~> 2)
+    simp-rake-helpers (3.1.3)
+      beaker (~> 2.51)
+      beaker-rspec (~> 5.0)
+      bundler (~> 1.0)
+      coderay (~> 1.0)
+      listen (~> 3.0.6)
+      pager
+      parallel (~> 1.0)
+      parallel_tests (~> 2.4)
+      puppet (>= 3.0)
+      puppet-blacksmith (~> 3.3)
+      puppet-lint (>= 1.0, < 3.0)
+      puppetlabs_spec_helper (~> 0.0)
+      r10k (~> 2.2)
+      rake (>= 10.0, < 12.0)
+      rspec (~> 3.0)
+      rspec-core (~> 3.0)
+      simp-beaker-helpers (~> 1.0)
+      simp-rspec-puppet-facts (~> 1.0)
+    simp-rspec-puppet-facts (1.4.1)
+      facter (>= 1.5.0, < 3.0)
+      json (~> 1)
+      rspec-puppet-facts (~> 0)
+    slop (3.6.0)
+    spdx-licenses (1.1.0)
+    specinfra (2.66.3)
+      net-scp
+      net-ssh (>= 2.7, < 4.0)
+      net-telnet
+      sfl
+    stringify-hash (0.0.2)
+    text (1.3.1)
+    thor (0.19.4)
+    travis (1.8.5)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
+    travis-lint (2.0.0)
+      json
+    travish (0.1.1)
+    trollop (2.1.2)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    uber (0.0.15)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    websocket (1.2.3)
+    yard (0.9.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  beaker!
+  beaker-rspec
+  guard-rake
+  hiera-puppet-helper
+  listen (~> 3.0.6)
+  metadata-json-lint
+  pry
+  pry-doc
+  puppet (~> 4)
+  puppet-blacksmith
+  puppet-lint-empty_string-check
+  puppet-lint-trailing_comma-check
+  puppet-strings
+  puppetlabs_spec_helper
+  rake
+  rspec
+  rspec-puppet
+  simp-beaker-helpers (~> 1.5)
+  simp-rake-helpers (~> 3.0)
+  simp-rspec-puppet-facts (~> 1.3)
+  travis
+  travis-lint
+  travish
+
+BUNDLED WITH
+   1.13.3

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,7 +54,6 @@
 #     you really know what you are doing.
 #
 # @param main_msg_queue_filename
-# @param main_msg_queue_max_file_size
 #
 # @param main_msg_queue_size
 #   The size of the main (global) message queue
@@ -164,6 +163,9 @@
 #   Disable DNS lookups for remote messages
 #
 #   * See the ``-x`` option in ``rsyslogd(8)`` for more information
+#
+# @param enable_default_rules
+#   Enables default rules for logging common services (e.g., iptables, puppet, slapd_auditd)
 #
 # @param read_journald
 #   Enable the forwarding of the ``systemd`` journal to syslog

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@
 # @param read_journald
 #   Enable the processing of ``journald`` messages natively in Rsyslog
 #
-# @param enable_logrotate
+# @param logrotate
 #   Ensure that ``logrotate`` is enabled on this system
 #
 #   * You will need to configure specific logrotate settings via the

--- a/manifests/server/firewall.pp
+++ b/manifests/server/firewall.pp
@@ -9,21 +9,21 @@ class rsyslog::server::firewall {
   assert_private()
 
   if $::rsyslog::tls_tcp_server {
-    iptables::add_tcp_stateful_listen { 'syslog_tls_tcp':
+    iptables::listen::tcp_stateful { 'syslog_tls_tcp':
       trusted_nets => $::rsyslog::trusted_nets,
       dports       => $::rsyslog::tls_tcp_listen_port
     }
   }
 
   if $::rsyslog::tcp_server {
-    iptables::add_tcp_stateful_listen { 'syslog_tcp':
+    iptables::listen::tcp_stateful { 'syslog_tcp':
       trusted_nets => $::rsyslog::trusted_nets,
       dports       => $::rsyslog::tcp_listen_port
     }
   }
 
   if $::rsyslog::udp_server {
-    iptables::add_udp_listen { 'syslog_udp':
+    iptables::listen::udp { 'syslog_udp':
       trusted_nets => $::rsyslog::trusted_nets,
       dports       => $::rsyslog::udp_listen_port
     }

--- a/metadata.json
+++ b/metadata.json
@@ -16,11 +16,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
       "name": "simp/logrotate",
@@ -28,11 +28,11 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
+      "version_requirement": ">= 3.1.0 < 4.0.0"
     },
     {
       "name": "simp/pki",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
       "name": "simp/tcpwrappers",

--- a/spec/acceptance/suites/default/01_client_server_no_tls_spec.rb
+++ b/spec/acceptance/suites/default/01_client_server_no_tls_spec.rb
@@ -35,8 +35,8 @@ rsyslog::server::enable_firewall : true
       # Turns off firewalld in EL7.  Presumably this would already be done.
       include 'iptables'
 
-      iptables::add_tcp_stateful_listen { 'ssh':
-        dports       => '22',
+      iptables::listen::tcp_stateful { 'ssh':
+        dports       => 22,
         trusted_nets => ['any'],
       }
 

--- a/spec/acceptance/suites/default/02_client_server_udp_spec.rb
+++ b/spec/acceptance/suites/default/02_client_server_udp_spec.rb
@@ -50,8 +50,8 @@ describe 'rsyslog class' do
     <<-EOS
       # Turns off firewalld in EL7.  Presumably this would already be done.
       include '::iptables'
-      iptables::add_tcp_stateful_listen { 'ssh':
-        dports       => '22',
+      iptables::listen::tcp_stateful { 'ssh':
+        dports       => 22,
         trusted_nets => ['any']
       }
 

--- a/spec/acceptance/suites/default/03_client_server_using_tls_spec.rb
+++ b/spec/acceptance/suites/default/03_client_server_using_tls_spec.rb
@@ -34,8 +34,8 @@ rsyslog::server::enable_firewall : true
     <<-EOS
       # Turns off firewalld in EL7.  Presumably this would already be done.
       include 'iptables'
-      iptables::add_tcp_stateful_listen { 'ssh':
-        dports       => '22',
+      iptables::listen::tcp_stateful { 'ssh':
+        dports       => 22,
         trusted_nets => ['any'],
       }
 

--- a/spec/acceptance/suites/default/04_failover_no_tls_spec.rb
+++ b/spec/acceptance/suites/default/04_failover_no_tls_spec.rb
@@ -86,8 +86,8 @@ describe 'rsyslog class' do
     <<-EOS
       # Turns off firewalld in EL7.  Presumably this would already be done.
       include '::iptables'
-      iptables::add_tcp_stateful_listen { 'ssh':
-        dports       => '22',
+      iptables::listen::tcp_stateful { 'ssh':
+        dports       => 22,
         trusted_nets => ['any']
       }
 

--- a/spec/acceptance/suites/default/05_failover_using_tls_spec.rb
+++ b/spec/acceptance/suites/default/05_failover_using_tls_spec.rb
@@ -95,8 +95,8 @@ describe 'rsyslog class' do
     <<-EOS
       # Turns off firewalld in EL7.  Presumably this would already be done.
       include '::iptables'
-      iptables::add_tcp_stateful_listen { 'ssh':
-        dports       => '22',
+      iptables::listen::tcp_stateful { 'ssh':
+        dports       => 22,
         trusted_nets => ['any']
       }
 

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -24,8 +24,77 @@ describe 'rsyslog::server' do
           let(:params) {{
             :enable_firewall => true
           }}
-          ###it_behaves_like 'a structured module'
+
           it { is_expected.to contain_class('rsyslog::server::firewall') }
+
+          context 'and tls_tcp_server enabled' do
+            let(:pre_condition) { 'class{ "rsyslog" : tls_tcp_server => true }' }
+            let(:params) {{ :enable_firewall => true }}
+            it {
+              is_expected.to create_iptables__listen__tcp_stateful('syslog_tls_tcp')
+                               .with_dports(6514)
+            }
+
+            context 'and tls_tcp_listen_port = 9999' do
+              let(:pre_condition) do
+                'class{ "rsyslog":
+                   tls_tcp_server => true,
+                   tls_tcp_listen_port => 9999,
+                }'
+              end
+              let(:params) {{ :enable_firewall => true }}
+              it {
+                is_expected.to create_iptables__listen__tcp_stateful('syslog_tls_tcp')
+                                 .with_dports(9999)
+              }
+            end
+          end
+
+          context 'and tcp_server enabled' do
+            let(:pre_condition) { 'class{ "rsyslog" : tcp_server => true }' }
+            let(:params) {{ :enable_firewall => true }}
+            it {
+              is_expected.to create_iptables__listen__tcp_stateful('syslog_tcp')
+                               .with_dports(514)
+            }
+
+            context 'and tcp_listen_port = 9999' do
+              let(:pre_condition) do
+                'class{ "rsyslog":
+                   tcp_server => true,
+                   tcp_listen_port => 9999,
+                }'
+              end
+              let(:params) {{ :enable_firewall => true }}
+              it {
+                is_expected.to create_iptables__listen__tcp_stateful('syslog_tcp')
+                                 .with_dports(9999)
+              }
+            end
+          end
+
+          context 'and udp_server enabled' do
+            let(:pre_condition) { 'class{ "rsyslog" : udp_server => true }' }
+            let(:params) {{ :enable_firewall => true }}
+            it {
+              is_expected.to create_iptables__listen__udp('syslog_udp')
+                               .with_dports(514)
+            }
+
+            context 'and udp_listen_port = 9999' do
+              let(:pre_condition) do
+                'class{ "rsyslog":
+                   udp_server => true,
+                   udp_listen_port => 9999,
+                }'
+              end
+              let(:params) {{ :enable_firewall => true }}
+              it {
+                is_expected.to create_iptables__listen__udp('syslog_udp')
+                                 .with_dports(9999)
+              }
+            end
+          end
         end
 
         context 'rsyslog::server class with SELinux enabled' do


### PR DESCRIPTION
Before this patch:

* `rsyslog::server::firewall` still used the API for
   pupmod-simp-iptables 5.x, which would fail during acceptance tests.

*  Spec tests for `rsyslog::server::firewall` checked that the toggle
   had worked, but didn't configure any of the `rsyslog` parameters that
   would actually configure the firewall.

* The versions loaded by .fixtures.yml and specified by metadata.json
  disagreed, resutling in a lot of warning chatter during acceptance
  tests.

This commit solves those issues by updating the iptables code to 6.x,
adding more robust tests for the `rsyslog::server::firewall` logic, and
updating the iptables syntax during the rsyslog beaker:suites.

SIMP-2439 #close
SIMP-2394 #close #comment locked dependencies
SIMP-1158 #comment fix minor strings errors in pupmod-simp-rsyslog