### PR TITLE
(SIMP-2663) Lastaction not being set properly for syslog rotate.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Feb 7 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.0.0-0
+- Updated expression in logrotate for lastaction to evaluate correctly
+
 * Wed Jan 11 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.0.0-0
 - Updated pki to use new scheme
 - Application certs now managed in /etc/pki/simp_apps/rsyslog/x509

--- a/manifests/config/logrotate.pp
+++ b/manifests/config/logrotate.pp
@@ -25,7 +25,7 @@ class rsyslog::config::logrotate (
 
   include '::logrotate'
 
-  $_restartcmd = 'systemd' in $facts['init_systems'] ? {
+  $_restartcmd = ('systemd' in $facts['init_systems']) ? {
     true    => '/usr/sbin/systemctl restart rsyslog',
     default => '/usr/sbin/service rsyslog restart'
   }


### PR DESCRIPTION
  - updated expression to execute correctly.

SIMP-2663 #close