### PR TITLE
(SIMP-2693) Fix rsyslog remote ruleset call name

### DIFF
--- a/spec/defines/rule/remote_spec.rb
+++ b/spec/defines/rule/remote_spec.rb
@@ -21,10 +21,10 @@ describe 'rsyslog::rule::remote' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_rsyslog__rule('10_simp_remote/test_name.conf').with_content(
-          /ruleset\(\n\s*name="#{title}_ruleset"/
+          /ruleset\(\n\s*name="ruleset_#{title}"/
         ) }
         it { is_expected.to contain_rsyslog__rule('10_simp_remote/test_name.conf').with_content(
-          /if \(#{params[:rule]}\) then call #{title}_ruleset/
+          /if \(#{params[:rule]}\) then call ruleset_#{title}/
         ) }
       end
     end

--- a/templates/rule/remote.erb
+++ b/templates/rule/remote.erb
@@ -11,7 +11,7 @@
   end
 -%>
 ruleset(
-  name="<%= @_safe_name %>_ruleset"
+  name="ruleset_<%= @_safe_name %>"
 ## TODO: Implement these once DA queues work properly inside of rulesets.
 #  queue.filename="<%= _queue_filename %>"
 <% if @queue_size -%>
@@ -220,4 +220,4 @@ ruleset(
 <% end -%>
 }
 
-if (<%= @rule.split("\n").collect{ |x| x.sub(/^\s+/,"") }.join("\n") %>) then call <%= @_safe_name %>_ruleset
+if (<%= @rule.split("\n").collect{ |x| x.sub(/^\s+/,"") }.join("\n") %>) then call ruleset_<%= @_safe_name %>


### PR DESCRIPTION
- "Calls" in rsyslog remote rules don't work when the first
  character is a number.
- Changed the call name to start with the word "ruleset".
- File names still start with the order to keep priority.

SIMP-2693 #close