### PR TITLE
(SIMP-2948) Use selinux status instead of catalyst

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Mar 28 2017 Nick Miller <nick.miller@onyxpoint.com> - 7.0.2-0
+- rsyslog::server now uses the state of selinux on the system instead
+  of simp_options
+
 * Thu Mar 23 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.0.2-0
 - Updated path for systemctl
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,21 +15,17 @@
 #
 class rsyslog::server (
   Boolean $enable_firewall    = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
-  Boolean $enable_selinux     = simplib::lookup('simp_options::selinux', { 'default_value' => false }),
   Boolean $enable_tcpwrappers = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false })
 ) {
   include '::rsyslog'
+
+  contain '::rsyslog::server::selinux'
+  Class['rsyslog::server::selinux'] -> Class['rsyslog::service']
 
   if $enable_firewall {
     contain '::rsyslog::server::firewall'
 
     Class['rsyslog::service'] -> Class['rsyslog::server::firewall']
-  }
-
-  if $enable_selinux {
-    contain '::rsyslog::server::selinux'
-
-    Class['rsyslog::server::selinux'] -> Class['rsyslog::service']
   }
 
   if $enable_tcpwrappers {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,17 +15,21 @@
 #
 class rsyslog::server (
   Boolean $enable_firewall    = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
+  Boolean $enable_selinux     = true,
   Boolean $enable_tcpwrappers = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false })
 ) {
   include '::rsyslog'
-
-  contain '::rsyslog::server::selinux'
-  Class['rsyslog::server::selinux'] -> Class['rsyslog::service']
 
   if $enable_firewall {
     contain '::rsyslog::server::firewall'
 
     Class['rsyslog::service'] -> Class['rsyslog::server::firewall']
+  }
+
+  if $enable_selinux {
+    contain '::rsyslog::server::selinux'
+
+    Class['rsyslog::server::selinux'] -> Class['rsyslog::service']
   }
 
   if $enable_tcpwrappers {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,7 +15,7 @@
 #
 class rsyslog::server (
   Boolean $enable_firewall    = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
-  Boolean $enable_selinux     = true,
+  Boolean $enable_selinux     = $facts['selinux_enforced'],
   Boolean $enable_tcpwrappers = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false })
 ) {
   include '::rsyslog'

--- a/metadata.json
+++ b/metadata.json
@@ -58,8 +58,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.x"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }


### PR DESCRIPTION
rsyslog::server used to use simp_options::selinux to determine if
selinux should be modified. Now it uses the current state of the system.

SIMP-2948 #close