### PR TITLE
(SIMP-3268) Problem default rsyslog rules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Fri May 26 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.3-0
+- Fixed bug in which default iptables rsyslog rule did not work
+  with rsyslog version 7.4.7.  Some versions of rsyslog include
+  the ' ' separator in the message payload, which impacts the
+  startswith rule.
+- Fixed bug whereby puppetserver log messages were not being
+  collected in puppetserver-specific logs.
+
 * Wed Apr 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 7.0.3-0
 - rsyslog::server::enable_selinux now optional, for robustness
 - Updated logrotate to use new lastaction API

--- a/files/config/rsyslog.default
+++ b/files/config/rsyslog.default
@@ -1,4 +1,4 @@
-if $syslogfacility-text == 'kern' and $msg startswith 'IPT:' then {
+if $syslogfacility-text == 'kern' and (($msg startswith ' IPT:') or ($msg startswith 'IPT:')) then {
   action(type="omfile" file="/var/log/iptables.log")
   stop
 }
@@ -11,11 +11,11 @@ if $programname == 'puppet-agent' then {
   stop
 }
 
-if $programname == 'puppet-master' and $syslogseverity-text == 'err' then {
-  action(type="omfile" file="/var/log/puppet-master-err.log")
+if $programname == 'puppetserver' and $syslogseverity-text == 'err' then {
+  action(type="omfile" file="/var/log/puppetserver-err.log")
 }
-if $programname == 'puppet-master' then {
-  action(type="omfile" file="/var/log/puppet-master.log")
+if $programname == 'puppetserver' then {
+  action(type="omfile" file="/var/log/puppetserver.log")
   stop
 }
 


### PR DESCRIPTION
- Fixed bug in which default iptables rsyslog rule did not work
  with rsyslog version 7.4.7.  Some versions of rsyslog include
  the ' ' separator in the message payload, which impacts the
  startswith rule.
- Fixed bug whereby puppetserver log messages were not being
  collected in puppetserver-specific logs.