### PR TITLE
WIP (SIMP-957) TLS  log server unencrypted syslog server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Mon Jul 30 2018 ralph-wright <ralph.wright@onyxpoint.com> - 7.2.0-0
+- Removed StreamDriver* directives from the global configuration, to
+  allow individual actions to control their specific stream settings.
+  This change was required to allow a host to send to remote syslog
+  servers for which the connection configurationrequirements differed.
+
 * Fri Jul 13 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.2.0-0
 - Add support for Puppet5 and OEL
 - Update acceptance tests to use environment variables

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 * Mon Jul 30 2018 ralph-wright <ralph.wright@onyxpoint.com> - 7.2.0-0
 - Removed StreamDriver* directives from the global configuration, to
   allow individual actions to control their specific stream settings.
-  This change was required to allow a host to send to remote syslog
-  servers for which the connection configurationrequirements differed.
+  This change was required to allow a host which is itself a syslog
+  server to receive TLS-encrypted data, but forward these messages
+  to a different remote syslog server as unencrypted data.
 
 * Fri Jul 13 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.2.0-0
 - Add support for Puppet5 and OEL

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -111,16 +111,6 @@ EOM
           it { is_expected.to contain_file('/etc/pki/simp_apps/rsyslog/x509')}
         end
 
-        context 'rsyslog class with TLS enabled' do
-          let(:params) {{
-            :tls_tcp_server => true
-          }}
-
-          it {
-            is_expected.to contain_file('/etc/rsyslog.simp.d/00_simp_pre_logging/global.conf').with_content(%r(^\$ActionSendStreamDriverAuthMode x509/name))
-          }
-        end
-
         context 'rsyslog class without TLS' do
           # rsyslog needs to disable pki/tls
           let(:params) {{
@@ -132,7 +122,6 @@ EOM
           it { is_expected.to_not contain_class('pki') }
           it { is_expected.to_not contain_pki__copy('rsyslog') }
           it { is_expected.to_not contain_file('/etc/pki/simp_apps/rsyslog/x509')}
-          it { is_expected.to contain_file('/etc/rsyslog.simp.d/00_simp_pre_logging/global.conf').with_content(/^\$ActionSendStreamDriverAuthMode anon/) }
         end
 
         context 'rsyslog class with TLS' do
@@ -146,7 +135,6 @@ EOM
           it { is_expected.to_not contain_class('pki') }
           it { is_expected.to contain_pki__copy('rsyslog') }
           it { is_expected.to contain_file('/etc/pki/simp_apps/rsyslog/x509')}
-          it { is_expected.to contain_file('/etc/rsyslog.simp.d/00_simp_pre_logging/global.conf').with_content(%r{^\$ActionSendStreamDriverAuthMode x509/name}) }
         end
 
         context 'rsyslog server without TLS' do

--- a/templates/config/pre_logging.conf.erb
+++ b/templates/config/pre_logging.conf.erb
@@ -162,13 +162,3 @@ $MainMsgQueueTimeoutEnqueue <%= @main_msg_queue_timeout_enqueue %>
 $MainMsgQueueDequeueSlowdown <%= @main_msg_queue_dequeue_slowdown %>
 $MainMsgQueueSaveOnShutdown <%= @main_msg_queue_save_on_shutdown %>
 $MainMsgQueueMaxDiskSpace <%= _main_msg_queue_max_disk_space %>
-
-#TODO: Remove these in favor of StreamDriver* directives directly in the actions themselves.
-$ActionSendStreamDriverMode <%= @action_send_stream_driver_mode %>
-$ActionSendStreamDriverAuthMode <%= @_action_send_stream_driver_auth_mode %>
-<% if @action_send_stream_driver_permitted_peers
-     @action_send_stream_driver_permitted_peers.each do |peer| -%>
-$ActionSendStreamDriverPermittedPeer <%= peer %>
-<%   end
-   end
--%>


### PR DESCRIPTION
Removed the SendStream settings from the global config.  This allows
each sending config to control how messages go out.

SIMP-957 #close