### PR TITLE
(SIMP-967) Cannot config TLS rsyslog server to unencrypted one

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+* Fri Aug 10 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.0-0
+- Reinstated ActionSendStreamDriverMode directive into the global
+  configuration when sending TLS-encrypted messages for Rsyslog
+  7 version, only. The sending of TLS-encrypted messages for CentOS 6
+  will not work otherwise.
+
+* Mon Jul 30 2018 ralph-wright <ralph.wright@onyxpoint.com> - 7.2.0-0
+- Remove all ActionSendStreamDriver* directives from the global
+  configuration, to allow individual actions to control their specific
+  stream settings.  This change was required to allow a host which is
+  itself a syslog server to receive TLS-encrypted data, but forward
+  these messages to a different remote syslog server as unencrypted data.
+
 * Fri Jul 13 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.2.0-0
 - Add support for Puppet5 and OEL
 - Update acceptance tests to use environment variables

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,12 +1,12 @@
-# Set up rsyslog 7
+# Set up Rsyslog 7/8
 #
 # The configuration is particularly slanted toward the issues present in the
-# version of rsyslog included with Enterprise Linux systems. It should still
+# versions of rsyslog included with Enterprise Linux systems. It should still
 # work on other systems but they may have different/other bugs that have not
 # been addressed.
 #
 # @param service_name
-#   The name of the RSyslog service; typically ``rsyslog``
+#   The name of the Rsyslog service; typically ``rsyslog``
 #
 # @param package_name
 #   The name of the Rsyslog package to install; typically ``rsyslog``
@@ -29,20 +29,20 @@
 #     and set the necessary global ``NetStreamDriver`` information.
 #
 # @param log_servers
-#   A list of primary RSyslog servers
+#   A list of primary Rsyslog servers
 #
 #   * All nodes in this list will get a copy of **all** logs if remote logging
 #     is enabled.
 #
 # @param failover_log_servers
-#   A list of the failover RSyslog servers
+#   A list of the failover Rsyslog servers
 #
 #   * This **order-dependent** list will serve as all of the possible failover
 #     log servers for clients to send to if the servers in ``log_servers`` are
 #     unavailable.
 #
 # @param queue_spool_directory
-#   The path to the directory where RSyslog should store disk message queues
+#   The path to the directory where Rsyslog should store disk message queues
 #
 # @param rule_dir
 #   The path at which all managed rules will begin
@@ -66,7 +66,8 @@
 #   Make this host listend for ``UDP`` connections
 #
 #   * This really should not be enabled unless you have devices that cannot
-#     speak ``TLS`` @param enable_logrotate
+#     speak ``TLS``
+#
 # @param udp_listen_address
 #   The address upon which to listen for ``UDP`` connections
 #
@@ -108,10 +109,7 @@
 #   Basepath of $default_net_stream_driver_ca_file, default_net_stream_driver_cert_file,
 #   and $default_net_stream_driver_key_file
 #
-# @author Chris Tessmer <chris.tessmer@onyxpoint.com>
-# @author Kendall Moore <kendall.moore@onyxpoint.com>
-# @author Mike Riddle <mike.riddle@onyxpoint.com>
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-rsyslog/graphs/contributors
 #
 class rsyslog (
   String                        $service_name            = $::rsyslog::params::service_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
-# A list of the parameters and their default values for RSyslog.
+# A list of the parameters and their default values for Rsyslog.
 #
 # @param service_name [String]
 #   The name of the rsyslog service
@@ -12,17 +12,23 @@
 # @param read_journald [Boolean]
 #   Tie in the reading of ``journald`` if available
 #
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @param rsyslog7 [Boolean]
+#   Whether Rsyslog 7 is being used.  This older version requires different
+#   configuration for ``TLS`` that the latest EL version.
+#
+# @author https://github.com/simp/pupmod-simp-rsyslog/graphs/contributors
 #
 class rsyslog::params {
   $service_name       = 'rsyslog'
   if ($facts['os']['name'] in ['RedHat','CentOS','OracleLinux']) and ($facts['os']['release']['major'] == '6') {
     $package_name  = 'rsyslog7'
     $read_journald = false
+    $rsyslog7      = true
   }
   else {
     $package_name  = 'rsyslog'
     $read_journald = true
+    $rsyslog7      = false
   }
 
   $tls_package_name = "${package_name}-gnutls"

--- a/spec/acceptance/nodesets/centos-6.yml
+++ b/spec/acceptance/nodesets/centos-6.yml
@@ -1,3 +1,10 @@
+<%
+  if ENV['BEAKER_HYPERVISOR']
+    hypervisor = ENV['BEAKER_HYPERVISOR']
+  else
+    hypervisor = 'vagrant'
+  end
+-%>
 HOSTS:
   client:
     roles:
@@ -6,26 +13,30 @@ HOSTS:
       - client
     platform:   el-6-x86_64
     box:        centos/6
-    hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
   server-1:
     roles:
       - server
     platform:   el-6-x86_64
     box:        centos/6
-    hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
   server-2:
     roles:
       - server
     platform:   el-6-x86_64
     box:        centos/6
-    hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
   server-3:
     roles:
       - failover_server
     platform:   el-6-x86_64
     box:        centos/6
     hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
 CONFIG:
   log_level:       verbose
   type:            aio
   vagrant_memsize: 256
+<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
+  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
+<% end -%>

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper_acceptance'
+require 'json'
 
 test_name 'rsyslog class'
 
@@ -112,18 +113,23 @@ input(type=\\"imfile\\"
 
 
     it 'should ensure rsyslog.service starts after network.target and network-online.target' do
-      # client uses systemd
-      # following 3 lines for debug
-      on client, 'rpm -q rsyslog'
-      on client, 'cat /usr/lib/systemd/system/rsyslog.service'
-      on client, 'systemctl show rsyslog.service'
+      facts = JSON.load(on(client, 'puppet facts').stdout)
+      if facts['values']['systemd']
+        # client uses systemd
+        # following 3 lines for debug
+        on client, 'rpm -q rsyslog'
+        on client, 'cat /usr/lib/systemd/system/rsyslog.service'
+        on client, 'systemctl show rsyslog.service'
 
-      on client, 'cat /etc/systemd/system/rsyslog.service.d/unit.conf'
+        on client, 'cat /etc/systemd/system/rsyslog.service.d/unit.conf'
 
-      [ 'Wants', 'After' ].each do |req|
-        result = on(client, "systemctl show rsyslog.service | grep ^#{req}=").stdout
-        expect(result).to match /network.target/
-        expect(result).to match /network-online.target/
+        [ 'Wants', 'After' ].each do |req|
+          result = on(client, "systemctl show rsyslog.service | grep ^#{req}=").stdout
+          expect(result).to match /network.target/
+          expect(result).to match /network-online.target/
+        end
+      else
+        puts "Skipping test on #{client.name}, which does not use systemd"
       end
     end
 

--- a/spec/acceptance/suites/doubleforward/01_client_tls_server_no_tls_nextserver_spec.rb
+++ b/spec/acceptance/suites/doubleforward/01_client_tls_server_no_tls_nextserver_spec.rb
@@ -1,0 +1,202 @@
+require 'spec_helper_acceptance'
+
+test_name 'client -> 1 server using TLS -> 1 server using plain TCP'
+
+describe 'rsyslog client -> 1 server using TLS -> 1 server using plain TCP' do
+
+  before(:context) do
+    hosts.each do |host|
+      interfaces = fact_on(host, 'interfaces').strip.split(',')
+      interfaces.delete_if do |x|
+        x =~ /^lo/
+      end
+
+      interfaces.each do |iface|
+        if fact_on(host, "ipaddress_#{iface}").strip.empty?
+          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
+        end
+      end
+    end
+  end
+
+  let(:client){ only_host_with_role( hosts, 'client' ) }
+  let(:server){ only_host_with_role( hosts, 'server' ) }
+  let(:nextserver){ only_host_with_role( hosts, 'nextserver' ) }
+  let(:client_fqdn){ fact_on( client, 'fqdn' ) }
+  let(:server_fqdn){ fact_on( server, 'fqdn' ) }
+  let(:nextserver_fqdn){ fact_on( nextserver, 'fqdn' ) }
+
+  let(:client_manifest) {
+    <<-EOS
+      class { 'rsyslog':
+        log_servers        => ['server-1'],
+        logrotate          => true,
+        enable_tls_logging => true,
+
+        # Using pki, but don't enable pki::copy
+        pki                => false,
+        app_pki_dir        => '/etc/pki/simp-testing/pki',
+      }
+
+      # Forward TLS-encrypted
+      rsyslog::rule::remote { 'send_the_logs_tls':
+        rule => 'prifilt(\\'*.*\\')'
+      }
+    EOS
+  }
+
+  let(:hieradata) {
+    <<-EOS
+---
+iptables::disable : false
+rsyslog::server::enable_firewall : true
+    EOS
+  }
+
+  let(:server_manifest) {
+    <<-EOS
+      # Turns off firewalld in EL7.  Presumably this would already be done.
+      include 'iptables'
+      iptables::listen::tcp_stateful { 'ssh':
+        dports       => 22,
+        trusted_nets => ['any'],
+      }
+
+      class { 'rsyslog':
+        log_servers        => ['server-2'],
+
+        # Outgoing logs should not be TLS-encrypted
+        # NOTE:  If we need to send to some follow-on servers that are
+        #        TLS-enabled and some that are not, will need to use
+        #        <host>:<port> format in the rsyslog::rule::remote
+        #        to distinguish the two cases, as that 'define' uses
+        #        rsyslog::rule::enable_tls_logging to determine the
+        #        otherwise unspecified port.
+        enable_tls_logging => false,
+
+        tls_tcp_server     => true,
+        logrotate          => true,
+
+        # Using pki for our TLS server, but don't enable pki::copy
+        pki                => false,
+        app_pki_dir        => '/etc/pki/simp-testing/pki',
+
+        trusted_nets       => ['any']
+      }
+
+      class { 'rsyslog::server':
+        enable_firewall    => true,
+        enable_selinux     => false,
+        enable_tcpwrappers => false,
+      }
+
+      # Forward plain TCP to our remote log servers
+      rsyslog::rule::remote { 'send_the_logs_plain_tcp':
+        stream_driver => 'tcp',
+        rule => 'prifilt(\\'*.*\\')'
+      }
+
+      # Also log in a local, host-named directory
+
+      # Define a dynamic file with an rsyslog template
+      # NOTE: puppet doesn't need to manage missing directories in this path;
+      #       rsyslog will create them as needed.
+      rsyslog::template::string { 'log_everything_by_host':
+        string => '/var/log/hosts/%HOSTNAME%/everything.log',
+      }
+
+      # Log all messages to the dynamic file we just defined ^^
+      rsyslog::rule::local { 'all_the_logs_tls':
+        rule      => 'prifilt(\\'*.*\\')',
+        dyna_file => 'log_everything_by_host'
+      }
+    EOS
+  }
+
+  let(:nextserver_manifest) {
+    <<-EOS
+      # Turns off firewalld in EL7.  Presumably this would already be done.
+      include 'iptables'
+      iptables::listen::tcp_stateful { 'ssh':
+        dports       => 22,
+        trusted_nets => ['any'],
+      }
+
+      class { 'rsyslog':
+        log_servers        => [],
+        enable_tls_logging => false,
+        tls_tcp_server     => false,
+        tcp_server         => true,
+        logrotate          => true,
+
+        # Not using pki at all
+        pki                => false,
+
+        trusted_nets       => ['any']
+      }
+
+      class { 'rsyslog::server':
+        enable_firewall    => true,
+        enable_selinux     => false,
+        enable_tcpwrappers => false,
+      }
+
+      # Define a dynamic file with an rsyslog template
+      # NOTE: puppet doesn't need to manage missing directories in this path;
+      #       rsyslog will create them as needed.
+      rsyslog::template::string { 'log_everything_by_host':
+        string => '/var/log/hosts/%HOSTNAME%/everything.log',
+      }
+
+      # Log all messages to the dynamic file we just defined ^^
+      rsyslog::rule::local { 'all_the_logs_plain_tcp':
+        rule      => 'prifilt(\\'*.*\\')',
+        dyna_file => 'log_everything_by_host'
+      }
+    EOS
+  }
+
+
+  context 'client and server configuration' do
+    it 'should configure first server without errors' do
+      set_hieradata_on(server, hieradata)
+      apply_manifest_on(server, server_manifest, :catch_failures => true)
+    end
+
+    it 'should configure first server idempotently' do
+      apply_manifest_on(server, server_manifest, :catch_changes => true)
+    end
+
+    it 'should configure next server without errors' do
+      set_hieradata_on(nextserver, hieradata)
+      apply_manifest_on(nextserver, nextserver_manifest, :catch_failures => true)
+    end
+
+    it 'should configure next server idempotently' do
+      apply_manifest_on(nextserver, nextserver_manifest, :catch_changes => true)
+    end
+
+    it 'should configure client without errors' do
+      apply_manifest_on(client, client_manifest, :catch_failures => true)
+    end
+
+    it 'should configure client idempotently' do
+      apply_manifest_on(client, client_manifest, :catch_changes => true)
+    end
+  end
+
+  context 'log forwarding' do
+    it 'client should successfully send log messages using TLS to 1st server' do
+      on client, 'logger -t FOO TEST-USING-TLS'
+      server_remote_log = "/var/log/hosts/#{client_fqdn}/everything.log"
+      on server, "test -f #{server_remote_log}"
+      on server, "grep TEST-USING-TLS #{server_remote_log}"
+    end
+
+    it '1st server should forward messages to non-TLS server using plain TCP' do
+      nextserver_remote_log = "/var/log/hosts/#{client_fqdn}/everything.log"
+      on nextserver, "test -f #{nextserver_remote_log}"
+      on nextserver, "grep TEST-USING-TLS #{nextserver_remote_log}"
+    end
+  end
+end

--- a/spec/acceptance/suites/doubleforward/nodesets/centos-6.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/centos-6.yml
@@ -1,0 +1,35 @@
+<%
+  if ENV['BEAKER_HYPERVISOR']
+    hypervisor = ENV['BEAKER_HYPERVISOR']
+  else
+    hypervisor = 'vagrant'
+  end
+-%>
+HOSTS:
+  client:
+    roles:
+      - default
+      - master
+      - client
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: <%= hypervisor %>
+  server-1:
+    roles:
+      - server
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: <%= hypervisor %>
+  server-2:
+    roles:
+      - nextserver
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: <%= hypervisor %>
+CONFIG:
+  log_level:       verbose
+  type:            aio
+  vagrant_memsize: 256
+<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
+  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
+<% end -%>

--- a/spec/acceptance/suites/doubleforward/nodesets/default.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/default.yml
@@ -1,0 +1,35 @@
+<%
+  if ENV['BEAKER_HYPERVISOR']
+    hypervisor = ENV['BEAKER_HYPERVISOR']
+  else
+    hypervisor = 'vagrant'
+  end
+-%>
+HOSTS:
+  client:
+    roles:
+      - default
+      - master
+      - client
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: <%= hypervisor %>
+  server-1:
+    roles:
+      - server
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: <%= hypervisor %>
+  server-2:
+    roles:
+      - nextserver
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: <%= hypervisor %>
+CONFIG:
+  log_level:       verbose
+  type:            aio
+  vagrant_memsize: 256
+<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
+  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
+<% end -%>

--- a/spec/acceptance/suites/doubleforward/nodesets/oel.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/oel.yml
@@ -1,0 +1,35 @@
+<%
+  if ENV['BEAKER_HYPERVISOR']
+    hypervisor = ENV['BEAKER_HYPERVISOR']
+  else
+    hypervisor = 'vagrant'
+  end
+-%>
+HOSTS:
+  client:
+    roles:
+      - default
+      - master
+      - client
+    platform:   el-7-x86_64
+    box:        elastic/oel-7-x86_64
+    hypervisor: <%= hypervisor %>
+  server-1:
+    roles:
+      - server
+    platform:   el-7-x86_64
+    box:        elastic/oel-7-x86_64
+    hypervisor: <%= hypervisor %>
+  server-2:
+    roles:
+      - nextserver
+    platform:   el-7-x86_64
+    box:        elastic/oel-7-x86_64
+    hypervisor: <%= hypervisor %>
+CONFIG:
+  log_level:       verbose
+  type:            aio
+  vagrant_memsize: 256
+<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
+  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
+<% end -%>

--- a/templates/config/pre_logging.conf.erb
+++ b/templates/config/pre_logging.conf.erb
@@ -59,7 +59,7 @@ global(
   dropMsgsWithMaliciousDnsPTRRecords="<%= @drop_msgs_with_malicious_dns_ptr_records %>"
   workDirectory="<%= @work_directory %>"
 )
-<% if @lsbmajdistrelease.to_i < 7 -%>
+<% if @_rsyslog7 -%>
 
 module(load="imklog")
 <% end -%>
@@ -163,12 +163,10 @@ $MainMsgQueueDequeueSlowdown <%= @main_msg_queue_dequeue_slowdown %>
 $MainMsgQueueSaveOnShutdown <%= @main_msg_queue_save_on_shutdown %>
 $MainMsgQueueMaxDiskSpace <%= _main_msg_queue_max_disk_space %>
 
-#TODO: Remove these in favor of StreamDriver* directives directly in the actions themselves.
+<% if @_rsyslog7  &&  @_enable_tls_logging  -%>
+# For Rsyslog 7, sending of TLS-encrypted messages does not work unless
+# this legacy, global config is set in addition to individual send stream
+# driver settings
+# TODO: Remove when support for Rsyslog 7 is dropped
 $ActionSendStreamDriverMode <%= @action_send_stream_driver_mode %>
-$ActionSendStreamDriverAuthMode <%= @_action_send_stream_driver_auth_mode %>
-<% if @action_send_stream_driver_permitted_peers
-     @action_send_stream_driver_permitted_peers.each do |peer| -%>
-$ActionSendStreamDriverPermittedPeer <%= peer %>
-<%   end
-   end
--%>
+<% end -%>

--- a/templates/rule/remote.erb
+++ b/templates/rule/remote.erb
@@ -3,17 +3,11 @@
     true  => 'on',
     false => 'off'
   }
-
-  if @queue_filename
-    _queue_filename = @queue_filename
-  else
-    _queue_filename = @_safe_name + '_disk_queue'
-  end
 -%>
 ruleset(
   name="ruleset_<%= @_safe_name %>"
 ## TODO: Implement these once DA queues work properly inside of rulesets.
-#  queue.filename="<%= _queue_filename %>"
+#  queue.filename="<%= @_queue_filename %>"
 <% if @queue_size -%>
 #  queue.size="<%= @queue_size %>"
 <% end -%>
@@ -57,105 +51,105 @@ ruleset(
 <% @_dest.each do |dest| -%>
 <%   _host,_port = dest.split(":") -%>
 <%
-    if _port.nil? || _port.empty?
-      if @_use_tls
-        _port = '6514'
-      else
-        _port = '514'
-      end
-    end
+     if _port.nil? || _port.empty?
+       if @_use_tls
+         _port = '6514'
+       else
+         _port = '514'
+       end
+     end
 -%>
   action(
     type="omfwd"
-<% if @template -%>
+<%   if @template -%>
     template="<%= @template %>"
-<% end -%>
+<%   end -%>
     protocol="<%= @dest_type %>"
     target="<%= _host %>"
     port="<%= _port %>"
-<% if @tcp_framing -%>
+<%   if @tcp_framing -%>
     TCP_Framing="<%= @tcp_framing %>"
-<% end -%>
-<% if @zip_level -%>
+<%   end -%>
+<%   if @zip_level -%>
     ZipLevel="<%= @zip_level %>"
-<% end -%>
-<% if @max_error_messages -%>
+<%   end -%>
+<%   if @max_error_messages -%>
 ## TODO: Implement this once we upgrade to v7-stable or later.
 #    maxErrorMessages="<%= @max_error_messages %>"
-<% end -%>
-<% if @compression_mode -%>
+<%   end -%>
+<%   if @compression_mode -%>
 ## TODO: Implement this once we upgrade to v7-stable or later.
 #    compression.mode="<%= @compression_mode %>"
-<% end -%>
+<%   end -%>
 ## TODO: Implement this once we upgrade to v7-stable or later.
 #    compression.stream.flushOnTXEnd="<%= _bool_xlat[@compression_stream_flush_on_tx_end] %>"
-<% if @rebind_interval -%>
+<%   if @rebind_interval -%>
     RebindInterval="<%= @rebind_interval %>"
-<% end -%>
-<% if @_use_tls -%>
-<%   if @stream_driver -%>
+<%   end -%>
+<%   if @_use_tls -%>
+<%     if @stream_driver -%>
     StreamDriver="<%= @stream_driver %>"
-<%   end -%>
-<%   if @stream_driver_mode -%>
+<%     end -%>
+<%     if @stream_driver_mode -%>
     StreamDriverMode="<%= @stream_driver_mode %>"
-<%   end -%>
-<%   if @stream_driver_auth_mode -%>
+<%     end -%>
+<%     if @stream_driver_auth_mode -%>
     StreamDriverAuthMode="<%= @stream_driver_auth_mode %>"
-<%   end -%>
-<%   if @stream_driver_permitted_peers -%>
+<%     end -%>
+<%     if @stream_driver_permitted_peers -%>
     StreamDriverPermittedPeers="<%= @stream_driver_permitted_peers %>"
+<%     end -%>
 <%   end -%>
-<% end -%>
     ResendLastMSGOnReconnect="<%= _bool_xlat[@resend_last_msg_on_reconnect] %>"
   )
 <% end -%>
 <%
-  if @_failover_servers.length > 0
-    _final_host = @_failover_servers.last
-    @_failover_servers.each do |s_target|
-      s_host,s_port = s_target.split(":")
-      if s_port.nil? || s_port.empty?
-        if @_use_tls
-          s_port = '6514'
-        else
-          s_port = '514'
-        end
-      end
+   if @_failover_servers.length > 0
+     _final_host = @_failover_servers.last
+     @_failover_servers.each do |s_target|
+       s_host,s_port = s_target.split(":")
+       if s_port.nil? || s_port.empty?
+         if @_use_tls
+           s_port = '6514'
+         else
+           s_port = '514'
+         end
+       end
 -%>
 
   action(
     type="omfwd"
-<% if @template -%>
+<%     if @template -%>
     template="<%= @template %>"
-<% end -%>
+<%     end -%>
     protocol="<%= @dest_type %>"
     target="<%= s_host %>"
     port="<%= s_port %>"
-<% if s_target.eql? _final_host -%>
+<%     if s_target.eql? _final_host -%>
 ## NOTE: This must exist for the last failover host so that we can queue logs to disk when needed.
-    queue.filename="<%= _queue_filename %>_action"
-<%   if @queue_size -%>
+    queue.filename="<%= @_queue_filename %>_action"
+<%       if @queue_size -%>
     queue.size="<%= @queue_size %>"
-<%   end -%>
+<%       end -%>
     queue.dequeuebatchsize="<%= @queue_dequeue_batch_size %>"
-<%   if @queue_max_disk_space -%>
+<%       if @queue_max_disk_space -%>
     queue.maxdiskspace="<%= @queue_max_disk_space %>"
-<%   end -%>
-<%   if @queue_high_watermark -%>
+<%       end -%>
+<%       if @queue_high_watermark -%>
     queue.highwatermark="<%= @queue_high_watermark %>"
-<%   end -%>
+<%       end -%>
     queue.lowwatermark="<%= @queue_low_watermark %>"
-<%   if @queue_full_delay_mark -%>
+<%       if @queue_full_delay_mark -%>
     queue.fulldelaymark="<%= @queue_full_delay_mark %>"
-<%   end -%>
-<%   if @queue_light_delay_mark -%>
+<%       end -%>
+<%       if @queue_light_delay_mark -%>
     queue.lightdelaymark="<%= @queue_light_delay_mark %>"
-<%   end -%>
+<%       end -%>
     queue.discardmark="<%= @queue_discard_mark %>"
     queue.discardseverity="<%= @queue_discard_severity %>"
-<%   if @queue_checkpoint_interval -%>
+<%       if @queue_checkpoint_interval -%>
     queue.checkpointinterval="<%= @queue_checkpoint_interval %>"
-<%   end -%>
+<%       end -%>
     queue.syncqueuefiles="<%= _bool_xlat[@queue_sync_queue_files] %>"
     queue.type="LinkedList"
     queue.workerthreads="<%= @queue_worker_threads %>"
@@ -167,53 +161,53 @@ ruleset(
     queue.maxfilesize="<%= @queue_max_file_size %>"
     queue.saveonshutdown="<%= _bool_xlat[@queue_save_on_shutdown] %>"
     queue.dequeueslowdown="<%= @queue_dequeue_slowdown %>"
-<%   if @queue_dequeue_time_begin -%>
+<%       if @queue_dequeue_time_begin -%>
     queue.dequeuetimebegin="<%= @queue_dequeue_time_begin %>"
-<%   end -%>
-<%   if @queue_dequeue_time_end -%>
+<%       end -%>
+<%       if @queue_dequeue_time_end -%>
     queue.dequeuetimeend="<%= @queue_dequeue_time_end %>"
-<%   end -%>
-<% end -%>
-<% if @tcp_framing -%>
+<%       end -%>
+<%     end -%>
+<%     if @tcp_framing -%>
     TCP_Framing="<%= @tcp_framing %>"
-<% end -%>
-<% if @zip_level -%>
+<%     end -%>
+<%     if @zip_level -%>
     ZipLevel="<%= @zip_level %>"
-<% end -%>
-<% if @max_error_messages -%>
+<%     end -%>
+<%     if @max_error_messages -%>
 ## TODO: Implement this once we upgrade to v7-stable or later.
 #    maxErrorMessages="<%= @max_error_messages %>"
-<% end -%>
-<% if @compression_mode -%>
+<%     end -%>
+<%     if @compression_mode -%>
 ## TODO: Implement this once we upgrade to v7-stable or later.
 #    compression.mode="<%= @compression_mode %>"
-<% end -%>
+<%     end -%>
 ## TODO: Implement this once we upgrade to v7-stable or later.
 #    compression.stream.flushOnTXEnd="<%= _bool_xlat[@compression_stream_flush_on_tx_end] %>"
-<% if @rebind_interval -%>
+<%     if @rebind_interval -%>
     RebindInterval="<%= @rebind_interval %>"
-<% end -%>
-<% if @_use_tls -%>
-<%   if @stream_driver -%>
+<%     end -%>
+<%     if @_use_tls -%>
+<%       if @stream_driver -%>
     StreamDriver="<%= @stream_driver %>"
-<%   end -%>
-<%   if @stream_driver_mode -%>
+<%       end -%>
+<%       if @stream_driver_mode -%>
     StreamDriverMode="<%= @stream_driver_mode %>"
-<%   end -%>
-<%   if @stream_driver_auth_mode -%>
+<%       end -%>
+<%       if @stream_driver_auth_mode -%>
     StreamDriverAuthMode="<%= @stream_driver_auth_mode %>"
-<%   end -%>
-<%   if @stream_driver_permitted_peers -%>
+<%       end -%>
+<%       if @stream_driver_permitted_peers -%>
     StreamDriverPermittedPeers="<%= @stream_driver_permitted_peers %>"
-<%   end -%>
-<% end -%>
+<%       end -%>
+<%     end -%>
     ResendLastMSGOnReconnect="<%= _bool_xlat[@resend_last_msg_on_reconnect] %>"
     action.resumeRetryCount="<%= @action_resume_retry_count %>"
     action.execOnlyWhenPreviousIsSuspended="on"
   )
 <%
-    end
-  end
+     end
+   end
 -%>
 <% if @stop_processing -%>
   stop


### PR DESCRIPTION
pupmod-simp-rsyslog does not allow a TSL encrypted server to
be configured to forward to a follow-on, unencrypted rsyslog server.

This PR incorporates the initial Rsyslog 8 solution provided by Ralph Wright.

- Removed all ActionSendStreamDriver* directives from the global
  configuration for Rsyslog 8.
- Only set ActionSendStreamDriverMode in global configuration
  for Rsyslog 7 when sending TLS-encrypted messages.
- Updated manifest documentation for clarity
- Fixed bug in default suite acceptance test that did not allow
  centos-6.yml node set to be run.
- Added a double forward acceptance test:
  client -> TLS server -> plain TCP server

SIMP-5137 #close
SIMP-5138 #close