### PR TITLE
(SIMP-5161) rsyslog server restart missing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Fri Aug 17 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.0-0
+- Fixed a bug in which removal of a rsyslog::rule from the catalog
+  did not cause the rsyslog service to restart, when other rules
+  corresponding to files in the same rsyslog configuration
+  subdirectory were present.
+
 * Fri Aug 10 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.0-0
 - Reinstated ActionSendStreamDriverMode directive into the global
   configuration when sending TLS-encrypted messages for Rsyslog

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -347,12 +347,18 @@ class rsyslog::config (
     mode   => '0755'
   }
 
+  $_readme = @(README)
+    # In Puppet hieradata, set 'rsyslog::config::include_rsyslog_d' to true
+    # and place ".conf" files that rsyslog should process independently of
+    # SIMP into this directory.
+    | README
+
   file { '/etc/rsyslog.d/README_SIMP.conf':
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => "# Place \".conf\" files that rsyslog should process independently of SIMP into this directory.\n"
+    content => $_readme
   }
 
   file { '/var/spool/rsyslog':

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -55,6 +55,8 @@ define rsyslog::rule (
   $_base_directory = "${::rsyslog::rule_dir}/${_name_array[0]}"
 
   if !defined(File[$_base_directory]) {
+    # Be sure to notify on directory changes so that rsyslog service
+    # is restarted when rules are removed.
     file { $_base_directory:
       ensure  => 'directory',
       owner   => 'root',
@@ -62,7 +64,8 @@ define rsyslog::rule (
       recurse => true,
       purge   => true,
       force   => true,
-      mode    => '0640'
+      mode    => '0640',
+      notify  => Class['rsyslog::service']
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,6 +10,14 @@ describe 'rsyslog' do
     it { is_expected.to contain_class('rsyslog') }
     it { is_expected.to contain_class('rsyslog::params') }
     it { is_expected.to contain_class('rsyslog::config') }
+    it {
+      expected = <<EOM
+# In Puppet hieradata, set 'rsyslog::config::include_rsyslog_d' to true
+# and place ".conf" files that rsyslog should process independently of
+# SIMP into this directory.
+EOM
+      is_expected.to contain_file('/etc/rsyslog.d/README_SIMP.conf').with_content(expected)
+    }
 
     it do
       is_expected.to contain_class('rsyslog::install').that_comes_before('Class[rsyslog::config]')

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -20,6 +20,7 @@ describe 'rsyslog::rule' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/etc/rsyslog.simp.d/some_path').with_ensure('directory') }
+        it { is_expected.to contain_file('/etc/rsyslog.simp.d/some_path').with_notify('Class[Rsyslog::Service]') }
         it { is_expected.to contain_file('/etc/rsyslog.simp.d/some_path.conf').with_content(
           %r(\$IncludeConfig\s+/etc/rsyslog.simp.d/some_path/\*\.conf)
         )}


### PR DESCRIPTION
- Fixed a bug in which removal of a rsyslog::rule from the catalog
  did not cause the rsyslog service to restart, when other rules
  corresponding to files in the same rsyslog configuration
  subdirectory were present.

- Clarified the explanation in /etc/rsyslog.d/README_SIMP.conf, as
  users have thought that simply dropping their custom rsyslog rules
  into /etc/rsyslog.d would be sufficient for these rules to be
  included in the rsyslog rule set.

SIMP-5161 #close