### PR TITLE
(SIMP-5099) Remove sudosh references from tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Aug 24 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.2.1-0
+- Updated the tests to no longer reference sudosh as our custom test since we
+  are moving away from using it and it could cause confusion.
+
 * Fri Aug 17 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.0-0
 - Fixed a bug in which removal of a rsyslog::rule from the catalog
   did not cause the rsyslog service to restart, when other rules

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsyslog",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "author": "SIMP Team",
   "summary": "A puppet module to support RSyslog versions 7 and higher using new style RainerScript.",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -63,9 +63,9 @@ input(type=\\"imfile\\"
         rule   => '$programname == \\'audispd\\''
       }
 
-      rsyslog::rule::local { '0_default_sudosh':
-        rule            => '$programname == \\'sudosh\\'',
-        dyna_file       => 'sudosh_template',
+      rsyslog::rule::local { '0_default_custom_test':
+        rule            => '$programname == \\'custom_test\\'',
+        dyna_file       => 'custom_test_template',
         stop_processing => true
       }
 
@@ -208,7 +208,7 @@ input(type=\\"imfile\\"
       on client, "test -f /etc/rsyslog.simp.d/06_simp_console/0_default_emerg.conf"
       on client, "test -f /etc/rsyslog.simp.d/05_simp_data_sources/openldap_audit.conf"
       on client, "test -f /etc/rsyslog.simp.d/07_simp_drop_rules/audispd.conf"
-      on client, "test -f /etc/rsyslog.simp.d/99_simp_local/0_default_sudosh.conf"
+      on client, "test -f /etc/rsyslog.simp.d/99_simp_local/0_default_custom_test.conf"
       on client, "test -f /etc/rsyslog.simp.d/20_simp_other/aide_report.conf"
       on client, "test -f /etc/rsyslog.simp.d/10_simp_remote/all_forward.conf"
 
@@ -244,7 +244,7 @@ input(type=\\"imfile\\"
       on client, 'test ! -d /etc/rsyslog.simp.d/05_simp_data_sources'
       on client, 'test ! -f /etc/rsyslog.simp.d/07_simp_drop_rules/audispd.conf'
       on client, 'test ! -d /etc/rsyslog.simp.d/07_simp_drop_rules'
-      on client, 'test ! -f /etc/rsyslog.simp.d/99_simp_local/0_default_sudosh.conf'
+      on client, 'test ! -f /etc/rsyslog.simp.d/99_simp_local/0_default_custom_test.conf'
       on client, 'test -d /etc/rsyslog.simp.d/99_simp_local'  # another rule still there
       on client, 'test ! -f /etc/rsyslog.simp.d/20_simp_other/aide_report.conf'
       on client, 'test ! -d /etc/rsyslog.simp.d/20_simp_other'


### PR DESCRIPTION
These were innocuous but could cause confusion as we move away from
using sudosh.