### PR TITLE
(SIMP-5157) StreamDriverPermittedPeers incorrect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+* Thu Aug 23 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> 7.2.0-0
+- When TLS is used to send t remote log servers the Permitted Peers
+  was being set to *.domain.  This worked as long as everything had
+  the same domain.  It was changed to default to HOSTNAME, which will
+  set the Peers to the name of the host used.  If the FQDN is not
+  being used in the server list or the certificates do not use the FQDN
+  as the  CN, then stream_driver_permitted_peers must be set.  See
+  https://media.readthedocs.org/pdf/rsyslog/stable/rsyslog.pdf for information
+  on what rsyslog is expecting.
+
 * Fri Aug 17 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.0-0
 - Fixed a bug in which removal of a rsyslog::rule from the catalog
   did not cause the rsyslog service to restart, when other rules

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,16 @@
 * Thu Aug 23 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> 7.2.0-0
-- When TLS is used to send t remote log servers the Permitted Peers
-  was being set to *.domain.  This worked as long as everything had
-  the same domain.  It was changed to default to HOSTNAME, which will
-  set the Peers to the name of the host used.  If the FQDN is not
-  being used in the server list or the certificates do not use the FQDN
-  as the  CN, then stream_driver_permitted_peers must be set.  See
-  https://media.readthedocs.org/pdf/rsyslog/stable/rsyslog.pdf for information
+- When TLS is used to send to remote log servers the Permitted Peers
+  was being set to *.domain.  This worked as long as the log server was in
+  the same domain as the client, which is not necesarily true.
+  The default was changed to "LOGSERVERNAME", which will
+  set the Peers in te forwarder to the name of the logserver host as set in
+  the dest parameter.  Since IP addresses are allowed to be used in the dest
+  parameter,  if LOGSERVERNAME is used it will check if the dest is a hostname
+  or an IP and issue and error if the dest param is not a hostname.
+  If the FQDN is not being used in the server list or the certificates do not use
+  the FQDN as the  CN or as an subject alt name, then stream_driver_permitted_peers
+  must be set.
+  See https://media.readthedocs.org/pdf/rsyslog/stable/rsyslog.pdf for information
   on what rsyslog is expecting.
 
 * Fri Aug 17 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.0-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
   was being set to *.domain.  This worked as long as the log server was in
   the same domain as the client, which is not necesarily true.
   The default was changed to "LOGSERVERNAME", which will
-  set the Peers in te forwarder to the name of the logserver host as set in
+  set the Peers in the forwarder to the name of the logserver host as set in
   the dest parameter.  Since IP addresses are allowed to be used in the dest
   parameter,  if LOGSERVERNAME is used it will check if the dest is a hostname
   or an IP and issue and error if the dest param is not a hostname.

--- a/manifests/rule/remote.pp
+++ b/manifests/rule/remote.pp
@@ -102,7 +102,7 @@
 # @param stream_driver_auth_mode
 # @param stream_driver_permitted_peers
 #   accepted fingerprint (SHA1) or name of remote peer. Note that this directive requires TLS netstream drivers.
-#   Each server in dest and failover_log_servers gets it own action.  If this is set to 'HOSTNAME'  it assumes the 
+#   Each server in dest and failover_log_servers gets it own action.  If this is set to 'LOGSERVERNAME'  it assumes the 
 #   list of servers is a FQDN and sets stream_driver_permitted_peers to the FQDN.  This setting needs to match
 #   the name used in the certificate from the server.  If you need to use IP Addresses or the certificates for the
 #   server do not use the hostname as the CN in the certificate then you must explicitly set this.
@@ -166,7 +166,7 @@ define rsyslog::rule::remote (
   Optional[String]                                 $stream_driver                        = undef,
   Integer[0]                                       $stream_driver_mode                   = 1,
   String                                           $stream_driver_auth_mode              = 'x509/name',
-  String                                           $stream_driver_permitted_peers        = 'HOSTNAME',
+  String                                           $stream_driver_permitted_peers        = 'LOGSERVERNAME',
   Boolean                                          $resend_last_msg_on_reconnect         = true,
   Boolean                                          $udp_send_to_all                      = false,
   Optional[String]                                 $queue_filename                       = undef,
@@ -239,18 +239,18 @@ define rsyslog::rule::remote (
     else {
       $_failover_servers = $failover_log_servers
     }
-    # If using TLS and stream_driver_permited peers is set to 'HOSTNAME'  check that
+    # If using TLS and stream_driver_permited peers is set to 'LOGSERVERNAME'  check that
     # the destination and failover servers are not using an IPADDRESS.
     if $_use_tls {
-      if $stream_driver_permitted_peers == "HOSTNAME" {
+      if $stream_driver_permitted_peers == "LOGSERVERNAME" {
         $_dest.each | $d | {
           assert_type(Variant[Simplib::Hostname,Simplib::Hostname::Port], $d ) | $x, $y | {
-            fail("If using TLS and stream_driver_permitted_peers is set to HOSTNAME, then you must use a host name for destination. ${d} is not a hostname.")
+            fail("If using TLS and stream_driver_permitted_peers is set to LOGSERVERNAME, then you must use a host name for destination. ${d} is not a hostname.")
           }
         }
         $_failover_servers.each | $f | {
           assert_type(Variant[Simplib::Hostname,Simplib::Hostname::Port], $f ) | $x, $y | {
-            fail("If using TLS and stream_driver_permitted_peers is set to HOSTNAME, then you must use a host name for failover srevers. ${d} is not a hostname.")
+            fail("If using TLS and stream_driver_permitted_peers is set to LOGSERVERNAME, then you must use a host name for failover srevers. ${d} is not a hostname.")
           }
         }
       }

--- a/spec/acceptance/suites/default/03_client_server_using_tls_spec.rb
+++ b/spec/acceptance/suites/default/03_client_server_using_tls_spec.rb
@@ -26,7 +26,7 @@ describe 'rsyslog client -> 1 server using TLS' do
   let(:client_manifest) {
     <<-EOS
       class { 'rsyslog':
-        log_servers        => ['server-1'],
+        log_servers        => ["#{server_fqdn}"],
         logrotate          => true,
         enable_tls_logging => true,
         pki                => false,
@@ -56,7 +56,7 @@ rsyslog::server::enable_firewall : true
       }
 
       class { 'rsyslog':
-        log_servers        => ['server-1'],
+        log_servers        => ["#{server_fqdn}"],
         tls_tcp_server     => true,
         logrotate          => true,
         enable_tls_logging => true,

--- a/spec/acceptance/suites/doubleforward/01_client_tls_server_no_tls_nextserver_spec.rb
+++ b/spec/acceptance/suites/doubleforward/01_client_tls_server_no_tls_nextserver_spec.rb
@@ -29,7 +29,7 @@ describe 'rsyslog client -> 1 server using TLS -> 1 server using plain TCP' do
   let(:client_manifest) {
     <<-EOS
       class { 'rsyslog':
-        log_servers        => ['server-1'],
+        log_servers        => ["#{server_fqdn}"],
         logrotate          => true,
         enable_tls_logging => true,
 

--- a/templates/rule/remote.erb
+++ b/templates/rule/remote.erb
@@ -97,7 +97,7 @@ ruleset(
     StreamDriverAuthMode="<%= @stream_driver_auth_mode %>"
 <%     end -%>
 <%     if @stream_driver_permitted_peers and !@stream_driver_permitted_peers.empty? -%>
-<%       if @stream_driver_permitted_peers  == "HOSTNAME"
+<%       if @stream_driver_permitted_peers  == "LOGSERVERNAME"
            _permitted_peers = _host
          else
            _permitted_peers = @stream_driver_permitted_peers
@@ -204,7 +204,7 @@ ruleset(
     StreamDriverAuthMode="<%= @stream_driver_auth_mode %>"
 <%       end -%>
 <%       if @stream_driver_permitted_peers and !@stream_driver_permitted_peers.empty? -%>
-<%         if @stream_driver_permitted_peers  == "HOSTNAME"
+<%         if @stream_driver_permitted_peers  == "LOGSERVERNAME"
              s_permitted_peers = s_host
            else
              s_permitted_peers = @stream_driver_permitted_peers

--- a/templates/rule/remote.erb
+++ b/templates/rule/remote.erb
@@ -96,8 +96,14 @@ ruleset(
 <%     if @stream_driver_auth_mode -%>
     StreamDriverAuthMode="<%= @stream_driver_auth_mode %>"
 <%     end -%>
-<%     if @stream_driver_permitted_peers -%>
-    StreamDriverPermittedPeers="<%= @stream_driver_permitted_peers %>"
+<%     if @stream_driver_permitted_peers and !@stream_driver_permitted_peers.empty? -%>
+<%       if @stream_driver_permitted_peers  == "HOSTNAME"
+           _permitted_peers = _host
+         else
+           _permitted_peers = @stream_driver_permitted_peers
+         end
+-%>
+    StreamDriverPermittedPeers="<%= _permitted_peers %>"
 <%     end -%>
 <%   end -%>
     ResendLastMSGOnReconnect="<%= _bool_xlat[@resend_last_msg_on_reconnect] %>"
@@ -197,8 +203,14 @@ ruleset(
 <%       if @stream_driver_auth_mode -%>
     StreamDriverAuthMode="<%= @stream_driver_auth_mode %>"
 <%       end -%>
-<%       if @stream_driver_permitted_peers -%>
-    StreamDriverPermittedPeers="<%= @stream_driver_permitted_peers %>"
+<%       if @stream_driver_permitted_peers and !@stream_driver_permitted_peers.empty? -%>
+<%         if @stream_driver_permitted_peers  == "HOSTNAME"
+             s_permitted_peers = s_host
+           else
+             s_permitted_peers = @stream_driver_permitted_peers
+           end
+-%>
+    StreamDriverPermittedPeers="<%= s_permitted_peers %>"
 <%       end -%>
 <%     end -%>
     ResendLastMSGOnReconnect="<%= _bool_xlat[@resend_last_msg_on_reconnect] %>"


### PR DESCRIPTION
- When a log server is in a different domain then the client,
  StreamDriverPermittedPeers was not set correctly.
  It defaulted to the domain of the client.  The
  default was changed to the log server destination or
  failover destination, which ever the rule is being configured for.

SIMP-5157 #close