### PR TITLE
(SIMP-5289) Update to camptocamp/systemd 2.1.0 for Puppet 5

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,9 +13,7 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
     stunnel: https://github.com/simp/pupmod-simp-stunnel
-    systemd:
-      repo: https://github.com/simp/puppet-systemd
-      branch: simp-master
+    systemd:  https://github.com/simp/puppet-systemd
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
   symlinks:
     rsyslog: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,10 +98,6 @@ cache:
 #
 # | Release   | Puppet | Ruby | End-of-Life Date |
 # |-----------|--------|------|------------------|
-# | PE 2016.4 | 4.7*   | 2.1  | 2018-10
-# | PE 2016.5 | 4.8    | 2.1  | 2017-05
-# | SIMP 6.0  | 4.8    | 2.1  | TBD
-# | PE 2017.1 | 4.9    | 2.1  | 2017-10
 # | PE 2017.2 | 4.10   | 2.1  | 2018-02
 # | SIMP 6.1  | 4.10   | 2.1  | TBD
 # | PE 2017.3 | 5.3    | 2.4  | 2018-08
@@ -110,14 +106,6 @@ cache:
 # * PE 2016.4 released with Puppet 4.7.0, but upgraded to the 4.10 series
 # starting with 2016.4.5.
 #
-
-.pe_2016_4: &pe_2016_4
-  variables:
-    PUPPET_VERSION: '~> 4.7.0'
-
-.simp_6_0: &simp_6_0
-  variables:
-    PUPPET_VERSION: '~> 4.8.1'
 
 .simp_6_1: &simp_6_1
   variables:
@@ -189,20 +177,6 @@ pup5_latest-lint:
 #
 
 # ----------------------------------------------------------------------
-# Puppet 4.7 for early releases of PE 2016.4 LTS
-pup4_7-unit:
-  <<: *unit_base
-  <<: *pe_2016_4
-  image: 'ruby:2.1'
-
-# ----------------------------------------------------------------------
-# Puppet 4.8 for SIMP 6 and PE 2016.5
-pup4_8-unit:
-  <<: *unit_base
-  <<: *simp_6_0
-  image: 'ruby:2.1'
-
-# ----------------------------------------------------------------------
 # Puppet 4.10 for SIMP 6.1, PE 2016.4 LTS, and 2017.2
 pup4_10-unit:
   <<: *unit_base
@@ -238,28 +212,6 @@ pup5_latest-unit:
 # Because acceptance tests are so much more expensive than other tests, this
 # test matrix is even more limited.  Here we stick to versions supported
 # by non-EOL meta-releases of SIMP and LTS versions of Puppet Enterprise.
-
-# ----------------------------------------------------------------------
-# Puppet 4.8 for SIMP 6.0 and PE 2016.5
-el-pup4_8:
-  <<: *acceptance_base
-  <<: *simp_6_0
-  script:
-    - 'bundle exec rake beaker:suites'
-
-el-pup4_8-fips:
-  <<: *acceptance_base
-  <<: *simp_6_0
-  variables:
-    BEAKER_fips: 'yes'
-  script:
-    - 'bundle exec rake beaker:suites'
-
-oel-pup4_8:
-  <<: *acceptance_base
-  <<: *simp_6_0
-  script:
-    - 'bundle exec rake beaker:suites[default,oel]'
 
 # ----------------------------------------------------------------------
 # Puppet 4.10 for SIMP 6.1, PE 2016.4 LTS, and PE 2017.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,18 +51,6 @@ jobs:
       script:
         - bundle exec rake spec
 
-    - stage: spec
-      rvm: 2.1.9
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
-      rvm: 2.1.9
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
-      script:
-        - bundle exec rake spec
-
     - stage: deploy
       rvm: 2.4.1
       script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Oct 03 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.1-0
+- Update to camptocamp/systemd 2.1.0 for Puppet 5
+
 * Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 7.2.1-0
 - Updated $app_pki_external_source to accept any string. This matches the
   functionality of pki::copy.

--- a/metadata.json
+++ b/metadata.json
@@ -14,8 +14,8 @@
     "syslog"
   ],
   "dependencies": [
-    { "name": "simp/systemd",
-      "version_requirement": ">= 1.1.1 < 2.0.0"
+    { "name": "camptocamp/systemd",
+      "version_requirement": ">= 2.1.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
- Update to camptocamp/systemd 2.1.0 for Puppet 5
- Remove old puppet tests that won't work with Hiera 5,
  as systemd 2.1.0 uses Hiera 5

SIMP-5289 #comment update rsyslog's systemd dependency