### PR TITLE
(SIMP-5289) Revert back to simp/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,7 +13,9 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
     stunnel: https://github.com/simp/pupmod-simp-stunnel
-    systemd:  https://github.com/simp/puppet-systemd
+    systemd:  
+      repo: https://github.com/simp/puppet-systemd
+      branch: simp-master
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
   symlinks:
     rsyslog: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Wed Oct 03 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.1-0
-- Update to camptocamp/systemd 2.1.0 for Puppet 5
+- Update range of simp/systemd to allow version with Hiera 5
 
 * Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 7.2.1-0
 - Updated $app_pki_external_source to accept any string. This matches the

--- a/metadata.json
+++ b/metadata.json
@@ -14,8 +14,8 @@
     "syslog"
   ],
   "dependencies": [
-    { "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
+    { "name": "simp/systemd",
+      "version_requirement": ">= 1.1.1 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Revert back to simp/systemd and expand version range allowed.
We cannot change back from simp/systemd to camptocamp/systemd
because of flaws in simp-adapter WRT RPM upgrades. We do want
to advance to version 2.1.0, but will have to pull that version
forward into our simp/systemd version. The simp-adapter problem
will be resolved when we rework packaging of modules in RPMs
(6.4.0 or later).