### PR TITLE
(SIMP-5315) Updated rsyslogd parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+* Mon Oct 08 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.2.1-0
+- Added logic to properly handle rsyslogd parameters for V8.6 and later
+  as documented in CentOS 7.5 Release notes.  These include moving -x and -w
+  options to global.conf and issuing deprecation warning for -l and -s
+  options.
+
+* Wed Oct 05 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.2.1-0
+- Added fact for version of rsyslogd
+- Updated templates to use RainerScript rsyslogd v8 and later
+- Fixed the MainMsgQueueDiscardMark and MainMsgQueueWorkerThreads
+  parameters
+
 * Wed Oct 03 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.1-0
 - Update range of simp/systemd to allow version with Hiera 5
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -186,11 +186,13 @@
 #     **way** up.
 #
 # @param host_list
+#   This option is only valid in rsyslog versions < 8.6.0
 #   Hosts that should be logged with their simple hostname
 #
 #   * See the ``-l`` option in ``rsyslogd(8)`` for more information
 #
 # @param domain_list
+#   This option is only valid in rsyslog versions < 8.6.0
 #   Array of domains that should be stripped off before logging
 #
 #   * See the ``-s`` option in ``rsyslogd(8)`` for more information
@@ -309,7 +311,7 @@ class rsyslog::config (
     $_read_journald = false
   }
 
-  # TODO When we drop Rsyslog 7 support, rename this to be 
+  # TODO When we drop Rsyslog 7 support, rename this to be
   #      tls_input_tcp_server_stream_driver_auth_mode
   if $action_send_stream_driver_auth_mode {
     $_action_send_stream_driver_auth_mode = $action_send_stream_driver_auth_mode
@@ -440,5 +442,15 @@ class rsyslog::config (
 
     # make sure service gets restarted after systemctl daemon-reload
     Class['systemd::systemctl::daemon_reload'] ~> Class['rsyslog::service']
+  }
+
+# give deprecation warning if rsyslog is 8.6 or later and the -l or -s options
+# are being used.
+  if $facts['rsyslogd'] and $facts['rsyslogd']['version'] {
+    if versioncmp($facts['rsyslogd']['version'], '8.6.0') > 0  {
+      if ! empty($host_list) or ! empty($domain_list) {
+        warning('Rsyslog has deprecated the -l and -s options in version 8.6.0 and later')
+      }
+    }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -444,12 +444,16 @@ class rsyslog::config (
     Class['systemd::systemctl::daemon_reload'] ~> Class['rsyslog::service']
   }
 
-# give deprecation warning if rsyslog is 8.6 or later and the -l or -s options
-# are being used.
+  # give deprecation warning if rsyslog is 8.6 or later and the -l or -s options
+  # are being used.
   if $facts['rsyslogd'] and $facts['rsyslogd']['version'] {
     if versioncmp($facts['rsyslogd']['version'], '8.6.0') > 0  {
-      if ! empty($host_list) or ! empty($domain_list) {
-        warning('Rsyslog has deprecated the -l and -s options in version 8.6.0 and later')
+      if ! empty($host_list) {
+        warning('rsyslog::config::host_list will be ignored: Rsyslog deprecated the -l option in version 8.6.0')
+      }
+
+      if ! empty($domain_list) {
+        warning('rsyslog::config::domain_list will be ignored: Rsyslog deprecated the -s option in version 8.6.0')
       }
     }
   }

--- a/spec/fixtures/hieradata/rsyslog_config_settings
+++ b/spec/fixtures/hieradata/rsyslog_config_settings
@@ -1,8 +1,0 @@
----
-rsyslog::config::host_list:
-  - 'my.host.com'
-
-rsyslog::config:;domain_list:
-  - 'foo.bar'
-
-rsyslog::config::disable_dns: true

--- a/spec/fixtures/hieradata/rsyslog_config_settings
+++ b/spec/fixtures/hieradata/rsyslog_config_settings
@@ -1,0 +1,8 @@
+---
+rsyslog::config::host_list:
+  - 'my.host.com'
+
+rsyslog::config:;domain_list:
+  - 'foo.bar'
+
+rsyslog::config::disable_dns: true

--- a/spec/fixtures/hieradata/rsyslog_config_settings.yaml
+++ b/spec/fixtures/hieradata/rsyslog_config_settings.yaml
@@ -1,0 +1,8 @@
+---
+rsyslog::config::host_list:
+  - 'my.host.com'
+
+rsyslog::config::domain_list:
+  - 'foo.bar'
+
+rsyslog::config::disable_remote_dns: true

--- a/templates/config/pre_logging.conf.erb
+++ b/templates/config/pre_logging.conf.erb
@@ -39,6 +39,11 @@
   unless @main_msg_queue_max_disk_space
     _main_msg_queue_max_disk_space = "#{(_main_msg_queue_size / 1024).round}M"
   end
+
+  _dns_enable = 'on'
+  if @disable_remote_dns
+    _dns_enable = 'off'
+  end
 -%>
 <%
   # Create a boolean translation hash for true/false -> on/off
@@ -58,6 +63,16 @@ global(
   preserveFQDN="<%= t_bool_xlat[@preserve_fqdn] %>"
   dropMsgsWithMaliciousDnsPTRRecords="<%= @drop_msgs_with_malicious_dns_ptr_records %>"
   workDirectory="<%= @work_directory %>"
+<%
+  if @facts['rsyslogd'] && @facts['rsyslogd']['version']
+    if scope.call_function('versioncmp', [@facts['rsyslogd']['version'], '8.6.0']) >= 0
+-%>
+  net.permitACLWarning="<%= t_bool_xlat[@suppress_noauth_warn] %>"
+  net.enableDNS="<%= _dns_enable %>"
+<%
+    end
+  end
+-%>
 )
 <%
   if @facts['rsyslogd'] && @facts['rsyslogd']['version']
@@ -65,8 +80,10 @@ global(
 -%>
 
 module(load="imklog")
-<%  end -%>
-<% end -%>
+<%
+    end
+  end
+-%>
 
 module(load="imuxsock"
   SysSock.IgnoreTimestamp="<%= t_bool_xlat[@syssock_ignore_timestamp] %>"

--- a/templates/sysconfig.erb
+++ b/templates/sysconfig.erb
@@ -1,4 +1,13 @@
 <%
+# Options x,l,s and w have been either deprecated or moved to the global conf file
+# in versions 8.6 and later of rsyslogd
+  if @facts['rsyslogd'] && @facts['rsyslogd']['version']
+    if scope.call_function('versioncmp', [@facts['rsyslogd']['version'], '8.6.0']) < 0
+
+-%>
+
+<%
+opts = ''
 unless @host_list.empty?
   opts = opts + " -l #{Array(@host_list).join(':')}"
 end
@@ -14,5 +23,9 @@ end
 if @disable_remote_dns
   opts = opts + " -x"
 end
+-%>
+<%
+    end
+  end
 -%>
 SYSLOGD_OPTIONS="<%= opts %>"

--- a/templates/sysconfig.erb
+++ b/templates/sysconfig.erb
@@ -3,28 +3,22 @@
 # in versions 8.6 and later of rsyslogd
   if @facts['rsyslogd'] && @facts['rsyslogd']['version']
     if scope.call_function('versioncmp', [@facts['rsyslogd']['version'], '8.6.0']) < 0
+      opts = ''
+      unless @host_list.empty?
+        opts = opts + " -l #{Array(@host_list).join(':')}"
+      end
 
--%>
+      unless @domain_list.empty?
+        opts = opts + " -s #{Array(@domain_list).join(':')}"
+      end
 
-<%
-opts = ''
-unless @host_list.empty?
-  opts = opts + " -l #{Array(@host_list).join(':')}"
-end
+      if @suppress_noauth_warn
+        opts = opts + " -w"
+      end
 
-unless @domain_list.empty?
-  opts = opts + " -s #{Array(@domain_list).join(':')}"
-end
-
-if @suppress_noauth_warn
-  opts = opts + " -w"
-end
-
-if @disable_remote_dns
-  opts = opts + " -x"
-end
--%>
-<%
+      if @disable_remote_dns
+        opts = opts + " -x"
+      end
     end
   end
 -%>


### PR DESCRIPTION
- Added logic to properly handle rsyslogd parameters for V8.6 and later
  as documented in CentOS 7.5 Release notes.  These include moving -x
  and -w options from parameters to entries in global.conf and issuing
  deprecation warning for -l and -s options.

SIMP-5315 #close
SIMP-5405 #close
SIMP-5406 #close
SIMP-5407 #close