### PR TITLE
(SIMP-5709) rsyslog acceptance tests fail on CentOS 6

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -88,6 +88,8 @@ input(type=\\"imfile\\"
     it 'should work with no errors' do
       apply_manifest_on(client, manifest, :catch_failures => true)
 
+      # requires 2 runs to be idempotent on centos6
+      apply_manifest_on(client, manifest, :catch_failures => true)
       # reboot to apply auditd changes
       # shell( 'shutdown -r now', { :expect_connection_failure => true } )
     end

--- a/spec/acceptance/suites/default/01_client_server_no_tls_spec.rb
+++ b/spec/acceptance/suites/default/01_client_server_no_tls_spec.rb
@@ -74,6 +74,9 @@ rsyslog::server::enable_firewall : true
     it 'should configure server without errors' do
       set_hieradata_on(server, hieradata)
       apply_manifest_on(server, server_manifest, :catch_failures => true)
+
+      # requires 2 runs to be idempotent on centos6
+      apply_manifest_on(server, server_manifest, :catch_failures => true)
     end
 
     it 'should configure server idempotently' do

--- a/spec/acceptance/suites/doubleforward/01_client_tls_server_no_tls_nextserver_spec.rb
+++ b/spec/acceptance/suites/doubleforward/01_client_tls_server_no_tls_nextserver_spec.rb
@@ -146,6 +146,9 @@ rsyslog::server::enable_firewall : true
     it 'should configure first server without errors' do
       set_hieradata_on(server, hieradata)
       apply_manifest_on(server, server_manifest, :catch_failures => true)
+
+      # requires 2 runs to be idempotent on centos6
+      apply_manifest_on(server, server_manifest, :catch_failures => true)
     end
 
     it 'should configure first server idempotently' do
@@ -155,6 +158,9 @@ rsyslog::server::enable_firewall : true
     it 'should configure next server without errors' do
       set_hieradata_on(nextserver, hieradata)
       apply_manifest_on(nextserver, nextserver_manifest, :catch_failures => true)
+
+      # requires 2 runs to be idempotent on centos6
+      apply_manifest_on(nextserver, nextserver_manifest, :catch_failures => true)
     end
 
     it 'should configure next server idempotently' do
@@ -162,6 +168,9 @@ rsyslog::server::enable_firewall : true
     end
 
     it 'should configure client without errors' do
+      apply_manifest_on(client, client_manifest, :catch_failures => true)
+
+      # requires 2 runs to be idempotent on centos6
       apply_manifest_on(client, client_manifest, :catch_failures => true)
     end
 

--- a/spec/acceptance/suites/failover/04_failover_no_tls_spec.rb
+++ b/spec/acceptance/suites/failover/04_failover_no_tls_spec.rb
@@ -115,6 +115,9 @@ describe 'rsyslog class' do
       (servers + failover_servers).each do |server|
         set_hieradata_on(server, server_manifest_hieradata)
         apply_manifest_on(server, server_manifest, :hiera_config => client.puppet['hiera_config'], :catch_failures => true)
+
+        # requires 2 runs to be idempotent on centos6
+        apply_manifest_on(server, server_manifest, :catch_failures => true)
       end
     end
 
@@ -127,6 +130,9 @@ describe 'rsyslog class' do
     it 'should configure the client without errors' do
       set_hieradata_on(client, client_manifest_hieradata)
       apply_manifest_on(client, client_manifest, :hiera_config => client.puppet['hiera_config'], :catch_failures => true)
+
+      # requires 2 runs to be idempotent on centos6
+      apply_manifest_on(client, client_manifest, :catch_failures => true)
     end
 
     it 'should configure client idempotently' do


### PR DESCRIPTION
Fixed all suites by compiling manifests twice before checking
for idempotency.  To verify the fixes, run each suite with its
corresponding centos-6 node set.

SIMP-5709 #close