### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,7 @@
 ---
 fixtures:
   repositories:
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     iptables: https://github.com/simp/pupmod-simp-iptables
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pki: https://github.com/simp/pupmod-simp-pki

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 7.3.1-0
+- Expanded the upper limit of the stdlib Puppet module version
+- Updated a URL in the README.md
+
 * Thu Oct 11 2018 Nick Miller <nick.miller@onyxpoint.com> - 7.3.0-0
 - Changed rsyslog::install::ensure from 'latest' to 'installed'
   - It will also respect `simp_options::package_ensure`

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ strategy for failover as it may cause undesirable results such as lost logs.
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 If you find any issues, they can be submitted to our
 [JIRA](https://simp-project.atlassian.net).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsyslog",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "author": "SIMP Team",
   "summary": "A puppet module to support RSyslog versions 7 and higher using new style RainerScript.",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/iptables",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limit of the stdlib Puppet module version
- Updated a URL in the README.md

SIMP-6213 #comment pupmod-simp-rsyslog