### PR TITLE
(SIMP-6922) concat pinned to wrong version in fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,9 +8,7 @@ fixtures:
     augeasproviders_core: https://github.com/hercules-team/augeasproviders_core
     augeasproviders_grub: https://github.com/hercules-team/augeasproviders_grub
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    concat:
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 5.3.0
+    concat: https://github.com/simp/puppetlabs-concat
     iptables: https://github.com/simp/pupmod-simp-iptables
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pki: https://github.com/simp/pupmod-simp-pki

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,10 +9,8 @@ fixtures:
     augeasproviders_grub: https://github.com/hercules-team/augeasproviders_grub
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
       repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+      ref: 5.3.0
     iptables: https://github.com/simp/pupmod-simp-iptables
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pki: https://github.com/simp/pupmod-simp-pki


### PR DESCRIPTION
- Tested with concat 5.3.0 to ensure compatibility with SIMP 6.4.0
- Updated fixtures to latest and greatest (6.x currently)