### PR TITLE
[SIMP-7177] fix broken include for rsyslog.d

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Oct 16 2019 Kendall Moore <kendall.moore@onyxpoint.com> - 7.5.1
+- Fixed a bug where including rsyslog.d parsed more than just .conf files
+
 * Thu Jun 06 2019 Steven Pritchard <steven.pritchard@onypoint.com> - 7.5.0-0
 - Add v2 compliance_markup data
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -407,7 +407,7 @@ class rsyslog::config (
 
   if $include_rsyslog_d {
     rsyslog::rule { '15_include_default_rsyslog/include_default_rsyslog.conf':
-      content => "\$IncludeConfig /etc/rsyslog.d/\n"
+      content => "\$IncludeConfig /etc/rsyslog.d/*.conf\n"
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsyslog",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "author": "SIMP Team",
   "summary": "A puppet module to support RSyslog versions 7 and higher using new style RainerScript.",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -118,7 +118,6 @@ EOM
             is_expected.to contain_class('systemd::systemctl::daemon_reload')
               .that_comes_before('Class[rsyslog::service]')
           end
-
         end
 
         it 'no file resources should have a literal \n' do
@@ -164,7 +163,6 @@ EOM
           :enable_tls_logging => false,
           :pki                => false,
          }}
-
 
         it { is_expected.to_not contain_class('pki') }
         it { is_expected.to_not contain_pki__copy('rsyslog') }
@@ -229,7 +227,6 @@ EOM
 
       end
 
-
       context 'rsyslog server without TLS' do
         # rsyslog needs to disable pki/tls
         let(:params) {{
@@ -243,7 +240,17 @@ EOM
         it { is_expected.to contain_file(global_conf_file).with_content(%r{input\(type="imtcp" port="514"\)}) }
         it { is_expected.to_not contain_file(global_conf_file).with_content(/^\$DefaultNetStreamDriver/) }
       end
+
+      context "including the rsyslog.d directory" do
+        let(:hieradata) { 'include_rsyslog_d' }
+        it {
+          is_expected.to contain_rsyslog__rule('15_include_default_rsyslog/include_default_rsyslog.conf')
+            .with_content('$IncludeConfig /etc/rsyslog.d/*.conf
+')
+	}
+      end
     end
+
     context "with later versions of rsyslog on #{os}" do
       let(:facts) do
         rsyslog_facts = {

--- a/spec/fixtures/hieradata/include_rsyslog_d.yaml
+++ b/spec/fixtures/hieradata/include_rsyslog_d.yaml
@@ -1,0 +1,2 @@
+---
+rsyslog::config::include_rsyslog_d: true


### PR DESCRIPTION
The $IncludeConfig for rsyslog.d should end in *.conf to ensure that
only valid config files are read and not other files that may exist in
that directory

SIMP-7177 #close