### PR TITLE
(SIMP-8134) Bump version to stop pipeline failures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Aug 03 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.6.3-0
+- Bumping version so pipeline stops failing on updated REFERENCE.md
+
 * Mon Jun 22 2020 Kendall Moore <kendall.moore@onyxpoint.com> - 7.6.2-0
 - Add support for KeepAlive variables for imtcp and omfwd actions
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsyslog",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "author": "SIMP Team",
   "summary": "A puppet module to support RSyslog versions 7 and higher using new style RainerScript.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This patch is a apriori version bump to enable the CI pipeline sanity
checks until SIMP-8134 gets sorted.

SIMP-8134 #comment bumped pupmod-simp-rsyslog as a workaround