### PR TITLE
(SIMP-8344) rsyslog has unreleased doc updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Jun 30 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.6.3-0
+- Update REFERENCE.md
+
 * Mon Jun 22 2020 Kendall Moore <kendall.moore@onyxpoint.com> - 7.6.2-0
 - Add support for KeepAlive variables for imtcp and omfwd actions
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsyslog",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "author": "SIMP Team",
   "summary": "A puppet module to support RSyslog versions 7 and higher using new style RainerScript.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Manually fix problem that used to be detected automatically by
pkg:compare_latest_tag rake task.

SIMP-8344 #close