### PR TITLE
(SIMP-9235) rsyslogd fact transforms string features to boolean

### DIFF
--- a/lib/facter/rsyslogd.rb
+++ b/lib/facter/rsyslogd.rb
@@ -21,12 +21,20 @@ Facter.add("rsyslogd") do
 
       rsyslogd_info.each do |info_line|
         if info_line =~ /\s+(.+):\s+(.+)$/
-          if $1 && $2
+          # Have to check for empty stripped $2 because regex will actually
+          # match a value string that has multiple whitespace characters.
+          # In that case $2 will contain a single whitespace character.
+          if $1 && $2 && !$2.strip.empty?
             key = $1.strip
             value = $2.strip
 
-            value = (value == 'Yes' ? true : false)
-            value = value.to_i if (value =~ /^\d+$/)
+            if value =~ /^yes$/i
+              value = true
+            elsif value =~ /^no$/i
+              value = false
+            elsif (value =~ /^\d+$/)
+              value = value.to_i
+            end
 
             response['features'][key] = value
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,7 @@ RSpec.configure do |c|
   }
 
   c.mock_framework = :rspec
-  c.mock_with :mocha
+  c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')

--- a/spec/unit/facter/rsyslogd_spec.rb
+++ b/spec/unit/facter/rsyslogd_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe 'custom fact rsyslogd' do
+  before(:each) do
+    Facter.clear
+
+    expect(Facter::Core::Execution).to receive(:which).with('rsyslogd').and_return('/usr/sbin/rsyslogd')
+  end
+
+  context 'with version info in expected format' do
+    let (:rsyslogd_info) { <<~EOM
+        rsyslogd  8.1911.0-6.el8 (aka 2019.11) compiled with:
+        \tPLATFORM:\t\t\t\tx86_64-redhat-linux-gnu
+        \tPLATFORM (lsb_release -d):\t\t
+        \tFEATURE_REGEXP:\t\t\t\tYes
+        \tGSSAPI Kerberos 5 support:\t\tYes
+        \tFEATURE_DEBUG (debug build, slow code):\tNo
+        \t32bit Atomic operations supported:\tYes
+        \t64bit Atomic operations supported:\tYes
+        \tmemory allocator:\t\t\tsystem default
+        \tRuntime Instrumentation (slow code):\tNo
+        \tuuid support:\t\t\t\tYes
+        \tsystemd support:\t\t\tYes
+        \tConfig file:\t\t\t\t/etc/rsyslog.conf
+        \tPID file:\t\t\t\t/var/run/rsyslogd.pid
+        \tNumber of Bits in RainerScript integers: 64
+
+        See https://www.rsyslog.com for more information.
+      EOM
+    }
+
+    let (:expected_fact) {{
+      'version'                                 => '8.1911.0',
+      'features'                                => {
+        'PLATFORM'                                => 'x86_64-redhat-linux-gnu',
+       # 'PLATFORM (lsb_release -d)' is omitted because it does not have a value
+        'FEATURE_REGEXP'                          => true,
+        'GSSAPI Kerberos 5 support'               => true,
+        'FEATURE_DEBUG (debug build, slow code)'  => false,
+        '32bit Atomic operations supported'       => true,
+        '64bit Atomic operations supported'       => true,
+        'memory allocator'                        => 'system default',
+        'Runtime Instrumentation (slow code)'     => false,
+        'uuid support'                            => true,
+        'systemd support'                         => true,
+        'Config file'                             => '/etc/rsyslog.conf',
+        'PID file'                                => '/var/run/rsyslogd.pid',
+        'Number of Bits in RainerScript integers' =>  64
+      }
+    }}
+
+    it 'should return hash with populated version and features' do
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/sbin/rsyslogd -v').and_return(rsyslogd_info)
+      expect(Facter.fact('rsyslogd').value).to eq(expected_fact)
+    end
+  end
+
+  context 'with version info in unexpected format' do
+    # non-standard version line ('rsyslogd version x.y.z' instead of
+    # 'rsyslogd x.y.z') and non-standard feature lines ('=' separator instead
+    # of ':" separator)
+    let (:rsyslogd_info) { <<~EOM
+        rsyslogd version 8.1911.0-6.el8 (aka 2019.11) compiled with:
+          PLATFORM = x86_64-redhat-linux-gnu
+          PLATFORM (lsb_release -d) =
+          FEATURE_REGEXP = Yes
+          GSSAPI Kerberos 5 support = Yes
+          FEATURE_DEBUG (debug build, slow code) = No
+          32bit Atomic operations supported = Yes
+          64bit Atomic operations supported = Yes
+          memory allocator = system default
+          Runtime Instrumentation (slow code) = No
+          uuid support = Yes
+          systemd support = Yes
+          Config file = /etc/rsyslog.conf
+          PID file = /var/run/rsyslogd.pid
+          Number of Bits in RainerScript integers =  64
+
+        See https://www.rsyslog.com for more information.
+      EOM
+    }
+
+    let (:expected_fact) { { 'version' => nil, 'features' => {} } }
+
+    it 'should return hash with nil version and empty features' do
+      expect(Facter::Core::Execution).to receive(:exec).with('/usr/sbin/rsyslogd -v').and_return(rsyslogd_info)
+      expect(Facter.fact('rsyslogd').value).to eq(expected_fact)
+    end
+  end
+end


### PR DESCRIPTION
Fixed a bug where the rsyslogd fact transformed all rsyslogd features
reported by 'rsyslogd -v' into boolean values, even though some
features should have been left as strings.

The logic flaws resulted in a warning message when the fact was loaded
in some versions of Puppet 7.

SIMP-9235 #close