### PR TITLE
(SIMP-10057) rsyslog Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,7 @@
 fixtures:
   repositories:
     auditd: https://github.com/simp/pupmod-simp-auditd.git
-    augeas_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
-      puppet_version: ">= 6.0.0"
+    augeas_core: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
     augeasproviders_core: https://github.com/hercules-team/augeasproviders_core.git
     augeasproviders_grub: https://github.com/hercules-team/augeasproviders_grub.git
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -337,8 +337,8 @@ pup7.x-unit:
 # Manually, we can see that failover is working, but all the messages
 # don't make it to the failover server in a timely fashion, even if
 # we force the rsyslog queues to be small.
-#pup5.pe-failover:
-#  <<: *pup_5_pe
+#pup6.pe-failover:
+#  <<: *pup_6_pe
 #  <<: *acceptance_base
 #  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
 #  script:
@@ -408,3 +408,17 @@ pup6.pe-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'
+
+pup7.x-doubleforward:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  script:
+    - 'bundle exec rake beaker:suites[doubleforward,default]'
+

--- a/spec/acceptance/nodesets/centos-7.yml
+++ b/spec/acceptance/nodesets/centos-7.yml
@@ -34,7 +34,7 @@ HOSTS:
     roles:
       - server
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
     yum_repos:
       chef-current:

--- a/spec/acceptance/nodesets/centos-7.yml
+++ b/spec/acceptance/nodesets/centos-7.yml
@@ -56,6 +56,10 @@ CONFIG:
   log_level: verbose
   type: aio
   vagrant_memsize: 256
+  ssh:
+    keepalive: true
+    keepalive_interval: 10
+    keepalive_maxcount: 60
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -11,7 +11,7 @@ HOSTS:
       - default
       - client
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
     yum_repos:
       chef-current:
@@ -22,7 +22,7 @@ HOSTS:
     roles:
       - server
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
     yum_repos:
       chef-current:
@@ -44,7 +44,7 @@ HOSTS:
     roles:
       - failover_server
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
     yum_repos:
       chef-current:

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -55,6 +55,10 @@ CONFIG:
   log_level: verbose
   type: aio
   vagrant_memsize: 256
+  ssh:
+    keepalive: true
+    keepalive_interval: 10
+    keepalive_maxcount: 60
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -36,6 +36,10 @@ CONFIG:
   log_level:       verbose
   type:            aio
   vagrant_memsize: 256
+  ssh:
+    keepalive: true
+    keepalive_interval: 10
+    keepalive_maxcount: 60
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/suites/doubleforward/nodesets/centos-7.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/centos-7.yml
@@ -30,6 +30,10 @@ CONFIG:
   log_level:       verbose
   type:            aio
   vagrant_memsize: 256
+  ssh:
+    keepalive: true
+    keepalive_interval: 10
+    keepalive_maxcount: 60
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/suites/doubleforward/nodesets/default.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/default.yml
@@ -12,19 +12,19 @@ HOSTS:
       - master
       - client
     platform:   el-8-x86_64
-    box:        centos/8
+    box:        generic/centos8
     hypervisor: <%= hypervisor %>
   server-1:
     roles:
       - server
     platform:   el-8-x86_64
-    box:        centos/8
+    box:        generic/centos8
     hypervisor: <%= hypervisor %>
   server-2:
     roles:
       - nextserver
     platform:   el-8-x86_64
-    box:        centos/8
+    box:        generic/centos8
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level:       verbose

--- a/spec/acceptance/suites/doubleforward/nodesets/default.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/default.yml
@@ -30,6 +30,10 @@ CONFIG:
   log_level:       verbose
   type:            aio
   vagrant_memsize: 256
+  ssh:
+    keepalive: true
+    keepalive_interval: 10
+    keepalive_maxcount: 60
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/acceptance/suites/doubleforward/nodesets/oel.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/oel.yml
@@ -30,6 +30,10 @@ CONFIG:
   log_level:       verbose
   type:            aio
   vagrant_memsize: 256
+  ssh:
+    keepalive: true
+    keepalive_interval: 10
+    keepalive_maxcount: 60
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -54,6 +54,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Remove check for Puppet >=6 in .fixtures.yml
* Test with CentOS 8.4 via generic/centos8 box
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-rsyslog acceptance tests configured
SIMP-10057 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666