### PR TITLE
Update deps to use puppet/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,7 +17,9 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     stunnel: https://github.com/simp/pupmod-simp-stunnel.git
-    systemd: https://github.com/simp/puppet-systemd.git
+    systemd:
+      repo: https://github.com/simp/puppet-systemd.git
+      branch: simp-master
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
     disa_stig-el7-baseline:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7.git

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 8.2.0
+- Update from camptocamp/systemd to puppet/systemd
+
 * Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 8.1.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -602,9 +602,6 @@ class rsyslog::config (
     systemd::dropin_file { $systemd_override_file:
       unit    => 'rsyslog.service',
       content => $_override
-    }
-
-    # make sure service gets restarted after systemctl daemon-reload
-    Class['systemd::systemctl::daemon_reload'] ~> Class['rsyslog::service']
+    } ~> Class['rsyslog::service']
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsyslog",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "author": "SIMP Team",
   "summary": "A puppet module to support RSyslog version 8.",
   "license": "Apache-2.0",
@@ -15,8 +15,8 @@
   ],
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.x < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 3.x < 4.0.0"
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/acceptance/nodesets/centos-7.yml
+++ b/spec/acceptance/nodesets/centos-7.yml
@@ -55,7 +55,7 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
+  vagrant_memsize: 512
   ssh:
     keepalive: true
     keepalive_interval: 10

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -54,7 +54,7 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 256
+  vagrant_memsize: 512
   ssh:
     keepalive: true
     keepalive_interval: 10

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -35,7 +35,7 @@ HOSTS:
 CONFIG:
   log_level:       verbose
   type:            aio
-  vagrant_memsize: 256
+  vagrant_memsize: 512
   ssh:
     keepalive: true
     keepalive_interval: 10

--- a/spec/acceptance/suites/doubleforward/nodesets/centos-7.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/centos-7.yml
@@ -29,7 +29,7 @@ HOSTS:
 CONFIG:
   log_level:       verbose
   type:            aio
-  vagrant_memsize: 256
+  vagrant_memsize: 512
   ssh:
     keepalive: true
     keepalive_interval: 10

--- a/spec/acceptance/suites/doubleforward/nodesets/default.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/default.yml
@@ -29,7 +29,7 @@ HOSTS:
 CONFIG:
   log_level:       verbose
   type:            aio
-  vagrant_memsize: 256
+  vagrant_memsize: 512
   ssh:
     keepalive: true
     keepalive_interval: 10

--- a/spec/acceptance/suites/doubleforward/nodesets/oel.yml
+++ b/spec/acceptance/suites/doubleforward/nodesets/oel.yml
@@ -29,7 +29,7 @@ HOSTS:
 CONFIG:
   log_level:       verbose
   type:            aio
-  vagrant_memsize: 256
+  vagrant_memsize: 512
   ssh:
     keepalive: true
     keepalive_interval: 10

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -129,11 +129,8 @@ describe 'rsyslog' do
             is_expected.to contain_systemd__dropin_file('unit.conf')
               .with( {
                 :unit => 'rsyslog.service',
-                :content => expected
-              } )
-
-            is_expected.to contain_class('systemd::systemctl::daemon_reload')
-              .that_comes_before('Class[rsyslog::service]')
+                :content => expected,
+              } ).that_comes_before('Class[rsyslog::service]')
           end
         end
 


### PR DESCRIPTION
This patch updates from camptocamp/systemd 2.x to puppet/systemd 3.x

This bump is driven by simp/simp-core#829