### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 8.3.0
+- Add RockyLinux 8 support
+
 * Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 8.2.0
 - Update from camptocamp/systemd to puppet/systemd
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -347,7 +347,7 @@
 # @api private
 class rsyslog::config (
   Simplib::Umask                        $umask                                              = '0027',
-  String                                $localhostname                                      = $facts['fqdn'],
+  String                                $localhostname                                      = $facts['networking']['fqdn'],
   Rsyslog::Boolean                      $preserve_fqdn                                      = true,
   String[1,1]                           $control_character_escape_prefix                    = '#',
   Rsyslog::Boolean                      $drop_msgs_with_malicious_dns_ptr_records           = false,
@@ -389,15 +389,15 @@ class rsyslog::config (
   Rsyslog::Boolean                      $repeated_msg_reduction                             = true,
   Stdlib::Absolutepath                  $work_directory                                     = '/var/spool/rsyslog',
   Integer[0]                            $tls_tcp_max_sessions                               = 200,
-  Array[String[1]]                      $tls_input_tcp_server_stream_driver_permitted_peers = ["*.${facts['domain']}"],
+  Array[String[1]]                      $tls_input_tcp_server_stream_driver_permitted_peers = ["*.${facts['networking']['domain']}"],
   Optional[Rsyslog::Boolean]            $keep_alive                                         = undef,
   Optional[Integer[0]]                  $keep_alive_probes                                  = undef,
   Optional[Integer[0]]                  $keep_alive_time                                    = undef,
 
   Enum['gtls','ptcp']                   $default_net_stream_driver                          = 'gtls',
   Stdlib::Absolutepath                  $default_net_stream_driver_ca_file                  = "${rsyslog::app_pki_dir}/cacerts/cacerts.pem",
-  Stdlib::Absolutepath                  $default_net_stream_driver_cert_file                = "${rsyslog::app_pki_dir}/public/${facts['fqdn']}.pub",
-  Stdlib::Absolutepath                  $default_net_stream_driver_key_file                 = "${rsyslog::app_pki_dir}/private/${facts['fqdn']}.pem",
+  Stdlib::Absolutepath                  $default_net_stream_driver_cert_file                = "${rsyslog::app_pki_dir}/public/${facts['networking']['fqdn']}.pub",
+  Stdlib::Absolutepath                  $default_net_stream_driver_key_file                 = "${rsyslog::app_pki_dir}/private/${facts['networking']['fqdn']}.pem",
 
   Optional[Enum['1','0']]               $action_send_stream_driver_mode                     = undef,
   Enum['1','0']                         $imtcp_stream_driver_mode                     = ($rsyslog::pki or $rsyslog::tls_tcp_server or $rsyslog::enable_tls_logging) ? { true => '1', default => '0' },

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,7 +13,7 @@ class rsyslog::install (
 ) {
   assert_private()
 
-  $_full_rsyslog_package = "${rsyslog::package_name}.${facts['hardwaremodel']}"
+  $_full_rsyslog_package = "${rsyslog::package_name}.${facts['os']['hardware']}"
 
   package { $_full_rsyslog_package:
     ensure => $ensure
@@ -21,7 +21,7 @@ class rsyslog::install (
 
   # Some hackery to remove the i386 version of rsyslog if you're on a x86_64
   # system.
-  if $facts['hardwaremodel'] == 'x86_64' {
+  if $facts['os']['hardware'] == 'x86_64' {
     package { "${rsyslog::package_name}.i386":
       ensure => 'absent',
       before => Package[$_full_rsyslog_package]

--- a/manifests/rule/remote.pp
+++ b/manifests/rule/remote.pp
@@ -304,7 +304,7 @@ define rsyslog::rule::remote (
         } else {
           # At least 1 IP address variant found, so, for backwards
           # compatibility, use the client's domain as a best-effort guess
-          $_stream_driver_permitted_peers = "*.${facts['domain']}"
+          $_stream_driver_permitted_peers = "*.${facts['networking']['domain']}"
           notify { "TLS StreamDriverPermittedPeers ${name}":
             message  => ("rsyslog::rule::remote ${_notify_msg}"),
             loglevel => 'warning',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,7 +15,7 @@
 #
 class rsyslog::server (
   Boolean           $enable_firewall    = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
-  Optional[Boolean] $enable_selinux     = $facts['selinux_enforced'],
+  Optional[Boolean] $enable_selinux     = $facts['os']['selinux']['enforced'],
   Boolean           $enable_tcpwrappers = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false })
 ) {
   include 'rsyslog'

--- a/manifests/server/selinux.pp
+++ b/manifests/server/selinux.pp
@@ -9,7 +9,7 @@
 class rsyslog::server::selinux {
   assert_private()
 
-  if $facts['selinux_current_mode'] and $facts['selinux_current_mode'] != 'disabled' {
+  if $facts['os']['selinux']['current_mode'] and $facts['os']['selinux']['current_mode'] != 'disabled' {
     selboolean { 'nis_enabled':
       persistent => true,
       value      => 'on'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsyslog",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "author": "SIMP Team",
   "summary": "A puppet module to support RSyslog version 8.",
   "license": "Apache-2.0",
@@ -16,11 +16,11 @@
   "dependencies": [
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 4.0.2 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/simplib",
@@ -66,6 +66,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.