### PR TITLE
Replace init_ulimit with systemd::dropin_file and support custom content in rsyslog.conf

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+* Thu Jul 16 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.1.0
+- Manage rsyslog's LimitNOFILE via a systemd drop-in file instead of editing
+  the shipped rsyslog.service unit. This preserves RPM file integrity.
+- Default value of `rsyslog::config::ulimit_max_open_files` is now
+  `'infinity'` (the systemd spelling). The legacy value `'unlimited'` is
+  still accepted but emits a deprecation warning.
+- Add `rsyslog::config::custom_conf_content` parameter, allowing arbitrary
+  content to be appended to `/etc/rsyslog.conf` after the managed
+  `$IncludeConfig` line (#147).
+
 * Fri Jul 03 2026 Steven Pritchard <steve@sicura.us> - 9.0.1
 - Match the EL9+ firewalld (nftables backend) denial-log format in the
   default firewall rule: messages are prefixed with the table name

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
-* Thu Jul 16 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.1.0
+* Wed Jul 22 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.1.0
 - Manage rsyslog's LimitNOFILE via a systemd drop-in file instead of editing
-  the shipped rsyslog.service unit. This preserves RPM file integrity.
+  the shipped rsyslog.service unit. This preserves RPM file integrity (#193).
+- Upgrade note: systems previously managed by this module have a modified
+  `/usr/lib/systemd/system/rsyslog.service`; run `rpm --restore rsyslog`
+  (or reinstall the rsyslog package) once after upgrading to clear the
+  existing RPM hash mismatch. This module does not rewrite the shipped
+  unit file back.
 - Default value of `rsyslog::config::ulimit_max_open_files` is now
   `'infinity'` (the systemd spelling). The legacy value `'unlimited'` is
   still accepted but emits a deprecation warning.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -418,7 +418,7 @@ class rsyslog::config (
   Optional[String]                      $imtcp_stream_driver_auth_mode                      = undef,
 
   Variant[Enum['infinity','unlimited'],Integer[0]] $ulimit_max_open_files                   = 'infinity',
-  Optional[String]                      $custom_conf_content                                = undef,
+  Optional[String[1]]                   $custom_conf_content                                = undef,
   Boolean                               $enable_default_rules                               = true,
   Optional[Boolean]                     $suppress_noauth_warn                               = undef,
   Rsyslog::Boolean                      $net_permit_acl_warning                             = true,
@@ -552,7 +552,6 @@ class rsyslog::config (
 
   $_custom_conf_content = $custom_conf_content ? {
     undef   => '',
-    ''      => '',
     default => "${custom_conf_content}\n",
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -250,6 +250,19 @@
 #
 #   * ``1024`` is fine for most purposes, but a collection server should bump this
 #     **way** up.
+#   * Applied via a ``systemd`` drop-in file so that the shipped
+#     ``rsyslog.service`` unit is not modified (preserves RPM integrity).
+#   * The legacy value ``'unlimited'`` is accepted for backwards
+#     compatibility and translated to ``'infinity'`` (the systemd
+#     spelling). A deprecation warning is emitted in that case.
+#
+# @param custom_conf_content
+#   Optional content appended verbatim to ``/etc/rsyslog.conf`` after the
+#   managed ``$IncludeConfig`` line.
+#
+#   * Intended for directives that must live in the main ``rsyslog.conf``
+#     file itself (rather than in ``${rsyslog::rule_dir}``).
+#   * No validation of the content is performed.
 #
 # @param enable_default_rules
 #   Enables default rules for logging common services (e.g., firewall, puppet, slapd_auditd)
@@ -404,7 +417,8 @@ class rsyslog::config (
   Optional[String]                      $action_send_stream_driver_auth_mode                = undef,
   Optional[String]                      $imtcp_stream_driver_auth_mode                      = undef,
 
-  Variant[Enum['unlimited'],Integer[0]] $ulimit_max_open_files                              = 'unlimited',
+  Variant[Enum['infinity','unlimited'],Integer[0]] $ulimit_max_open_files                   = 'infinity',
+  Optional[String]                      $custom_conf_content                                = undef,
   Boolean                               $enable_default_rules                               = true,
   Optional[Boolean]                     $suppress_noauth_warn                               = undef,
   Rsyslog::Boolean                      $net_permit_acl_warning                             = true,
@@ -446,6 +460,14 @@ class rsyslog::config (
 
   if $disable_remote_dns !~ Undef {
     warning('rsyslog::config::disable_remote_dns is deprecated. Use rsyslog::config::net_enable_dns instead')
+  }
+
+  if $ulimit_max_open_files == 'unlimited' {
+    warning("rsyslog::config::ulimit_max_open_files value 'unlimited' is deprecated. Use 'infinity' instead.")
+    $_ulimit_max_open_files = 'infinity'
+  }
+  else {
+    $_ulimit_max_open_files = $ulimit_max_open_files
   }
 
   $_tcp_server = $rsyslog::tcp_server
@@ -528,6 +550,12 @@ class rsyslog::config (
     }
   }
 
+  $_custom_conf_content = $custom_conf_content ? {
+    undef   => '',
+    ''      => '',
+    default => "${custom_conf_content}\n",
+  }
+
   $_rsyslog_conf = @("RSYSLOG_CONF"/$)
     # This file is managed by Puppet (simp/rsyslog module).
     # Any changes will be overwritten.
@@ -539,7 +567,7 @@ class rsyslog::config (
     owner   => 'root',
     group   => 'root',
     mode    => '0600',
-    content => $_rsyslog_conf
+    content => "${_rsyslog_conf}${_custom_conf_content}",
   }
 
   $_sysconfig_rsyslog = @(SYSCONFIG_RSYSLOG)
@@ -576,12 +604,20 @@ class rsyslog::config (
     }
   }
 
-  # Set the maximum number of open files in the init script.
-  init_ulimit { 'mod_open_files_rsyslog':
-    target => 'rsyslog',
-    item   => 'max_open_files',
-    value  => $ulimit_max_open_files
-  }
+  # Set the maximum number of open files via a systemd drop-in so that the
+  # shipped /usr/lib/systemd/system/rsyslog.service unit is not modified.
+  # Modifying the shipped unit causes RPM hash mismatches.
+  $_limits_dropin = @("LIMITS"/$)
+    # This file is managed by Puppet (simp/rsyslog module).
+    # Any changes will be overwritten.
+    [Service]
+    LimitNOFILE=${_ulimit_max_open_files}
+    | LIMITS
+
+  systemd::dropin_file { 'simp_limits.conf':
+    unit    => 'rsyslog.service',
+    content => $_limits_dropin,
+  } ~> Class['rsyslog::service']
 
   if $facts['rsyslogd'] and ($facts['rsyslogd']['version'] == '8.24.0') {
     # This systemd override addresses a systemd service file bug present in the

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsyslog",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "author": "SIMP Team",
   "summary": "A puppet module to support RSyslog version 8.",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -355,11 +355,7 @@ describe 'rsyslog' do
       end
 
       context 'with custom_conf_content set' do
-        let(:params) do
-          {
-            custom_conf_content: '$WorkDirectory /var/spool/rsyslog',
-          }
-        end
+        let(:hieradata) { 'custom_conf_content' }
 
         it { is_expected.to compile.with_all_deps }
         it {
@@ -374,7 +370,7 @@ describe 'rsyslog' do
       end
 
       context 'with ulimit_max_open_files set to an integer' do
-        let(:params) { { ulimit_max_open_files: 65_536 } }
+        let(:hieradata) { 'ulimit_max_open_files_integer' }
 
         it { is_expected.to compile.with_all_deps }
         it {
@@ -384,7 +380,7 @@ describe 'rsyslog' do
       end
 
       context "with the deprecated ulimit_max_open_files value 'unlimited'" do
-        let(:params) { { ulimit_max_open_files: 'unlimited' } }
+        let(:hieradata) { 'ulimit_max_open_files_unlimited' }
 
         it { is_expected.to compile.with_all_deps }
         it {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -66,12 +66,19 @@ describe 'rsyslog' do
     it { is_expected.to contain_rsyslog__rule('00_simp_pre_logging/global.conf') }
     it { is_expected.to contain_rsyslog__rule('09_failover_hack/failover_hack.conf') }
     it {
-      is_expected.to contain_init_ulimit('mod_open_files_rsyslog').with(
-      target: 'rsyslog',
-      item: 'max_open_files',
-      value: 'unlimited',
-    )
+      expected = <<~EOM
+        # This file is managed by Puppet (simp/rsyslog module).
+        # Any changes will be overwritten.
+        [Service]
+        LimitNOFILE=infinity
+      EOM
+
+      is_expected.to contain_systemd__dropin_file('simp_limits.conf').with(
+        unit: 'rsyslog.service',
+        content: expected,
+      ).that_notifies('Class[rsyslog::service]')
     }
+    it { is_expected.not_to contain_init_ulimit('mod_open_files_rsyslog') }
   end
 
   shared_examples_for 'rsyslog base service' do
@@ -345,6 +352,45 @@ describe 'rsyslog' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file(global_conf_file).with_content(global_expected) }
+      end
+
+      context 'with custom_conf_content set' do
+        let(:params) do
+          {
+            custom_conf_content: '$WorkDirectory /var/spool/rsyslog',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          expected = <<~EOM
+            # This file is managed by Puppet (simp/rsyslog module).
+            # Any changes will be overwritten.
+            $IncludeConfig /etc/rsyslog.simp.d/*.conf
+            $WorkDirectory /var/spool/rsyslog
+          EOM
+          is_expected.to contain_file('/etc/rsyslog.conf').with_content(expected)
+        }
+      end
+
+      context 'with ulimit_max_open_files set to an integer' do
+        let(:params) { { ulimit_max_open_files: 65_536 } }
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_systemd__dropin_file('simp_limits.conf')
+            .with_content(%r{LimitNOFILE=65536})
+        }
+      end
+
+      context "with the deprecated ulimit_max_open_files value 'unlimited'" do
+        let(:params) { { ulimit_max_open_files: 'unlimited' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_systemd__dropin_file('simp_limits.conf')
+            .with_content(%r{LimitNOFILE=infinity})
+        }
       end
 
       context 'with a rules hash defined' do

--- a/spec/fixtures/hieradata/custom_conf_content.yaml
+++ b/spec/fixtures/hieradata/custom_conf_content.yaml
@@ -1,0 +1,2 @@
+---
+rsyslog::config::custom_conf_content: '$WorkDirectory /var/spool/rsyslog'

--- a/spec/fixtures/hieradata/ulimit_max_open_files_integer.yaml
+++ b/spec/fixtures/hieradata/ulimit_max_open_files_integer.yaml
@@ -1,0 +1,2 @@
+---
+rsyslog::config::ulimit_max_open_files: 65536

--- a/spec/fixtures/hieradata/ulimit_max_open_files_unlimited.yaml
+++ b/spec/fixtures/hieradata/ulimit_max_open_files_unlimited.yaml
@@ -1,0 +1,2 @@
+---
+rsyslog::config::ulimit_max_open_files: 'unlimited'


### PR DESCRIPTION
- Replace the simplib init_ulimit resource with a systemd::dropin_file so the shipped rsyslog.service unit is no longer modified in place, which preserves RPM file integrity (#193).
- Default `rsyslog::config::ulimit_max_open_files` is now 'infinity'. 'unlimited' is still accepted but emits a deprecation warning and is translated to 'infinity' on the wire.
- Add `rsyslog::config::custom_conf_content`, an optional string appended verbatim to /etc/rsyslog.conf after the managed $IncludeConfig line (#147).