### PR TITLE
Match EL9+ firewalld denial-log format in the default firewall rule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri Jul 03 2026 Steven Pritchard <steve@sicura.us> - 9.0.1
+- Match the EL9+ firewalld (nftables backend) denial-log format in the
+  default firewall rule: messages are prefixed with the table name
+  (`filter_IN_99_simp_DROP:`), which the previous `startswith` match missed
+
 * Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 9.0.0
 - Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
 - Point `issues_url` at GitHub Issues

--- a/files/config/rsyslog.default
+++ b/files/config/rsyslog.default
@@ -3,7 +3,7 @@ if $syslogfacility-text == 'kern' and (($msg startswith ' IPT:') or ($msg starts
   stop
 }
 
-if $syslogfacility-text == 'kern' and (($msg startswith ' IN_99_simp_DROP:') or ($msg startswith 'IN_99_simp_DROP:')) then {
+if $syslogfacility-text == 'kern' and ($msg contains 'IN_99_simp_DROP:') then {
   action(type="omfile" file="/var/log/firewall.log")
   stop
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsyslog",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "author": "SIMP Team",
   "summary": "A puppet module to support RSyslog version 8.",
   "license": "Apache-2.0",


### PR DESCRIPTION
firewalld's nftables backend (EL9+) prefixes denial log messages with the table name (`filter_IN_99_simp_DROP:`), which the `startswith` match in `files/config/rsyslog.default` missed — denials never reached `/var/log/firewall.log`. Use `contains` to cover both the legacy and table-prefixed forms.

Verified against live almalinux9 kernel logs:
```
kernel: filter_IN_99_simp_DROP: IN=eth1 ... PROTO=ICMP TYPE=8 ...
```

- Version 9.0.1 + CHANGELOG
- Unit suite: 2187 examples, 0 failures
- Validated end-to-end by pupmod-simp-simp_rsyslog's acceptance suite (almalinux9: 21 examples, 0 failures — the firewall-log collection examples pass with this fix in the fixture)

**Merge-order note:** simp_rsyslog#115's acceptance CI pulls this module from master as a fixture, so this should merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)